### PR TITLE
Add pagebreak penalties before online and avmedia literature sections

### DIFF
--- a/hgbbib.sty
+++ b/hgbbib.sty
@@ -42,12 +42,14 @@
 }
 
 \defbibheading{avmedia}{%
+	\pagebreak[3]%
 	\phantomsection%
 	\section*{\@bibtitleAvmedia}%
 	\addcontentsline{toc}{section}{\@bibtitleAvmedia}%
 }
 
 \defbibheading{online}{%
+	\pagebreak[3]%
 	\phantomsection%
 	\section*{\@bibtitleOnline}%
 	\addcontentsline{toc}{section}{\@bibtitleOnline}%


### PR DESCRIPTION
This ensures that the links created by \phantomsection link to the correct page when the section title is the first item on a new page

You can see the change in the the toc on the left of the two pictures i attached.
Before the section "Online-Quellen" linked to the bottom of page 8.
After the fix the section linkes to the top of the "Online-Quellen" on page 9.

![before](https://user-images.githubusercontent.com/5493144/30907263-7a480c7a-a37a-11e7-97dd-648a7b449a6f.png)
![after](https://user-images.githubusercontent.com/5493144/30907262-7a451b50-a37a-11e7-86c9-735443d6c927.png)