### PR TITLE
Updates to bibliography setup

### DIFF
--- a/hgbbib.sty
+++ b/hgbbib.sty
@@ -145,3 +145,4 @@
 \DeclareBibliographyAlias{software}{misc}
 \DeclareBibliographyAlias{electronic}{misc}
 \DeclareBibliographyAlias{image}{misc}
+\DeclareBibliographyAlias{standard}{misc}

--- a/hgbbib.sty
+++ b/hgbbib.sty
@@ -67,59 +67,28 @@
 
 \defbibheading{noheader}[]{}		% 'none' should be defined but isn't
 
-
-
-
-% hook to add a given reference to its bibliography category
-%\AtEveryCitekey{%
-	%\ifthenelse{%
-		%\ifentrytype{online}\OR
-		%\ifentrytype{www}
-	%}{\addtocategory{online}{\thefield{entrykey}}}%
-	%{%
-	%\ifthenelse{%
-		%\ifentrytype{movie}\OR
-		%\ifentrytype{video}\OR
-		%\ifentrytype{music}\OR
-		%\ifentrytype{audio}\OR
-		%\ifentrytype{image}
-	%}{\addtocategory{avmedia}{\thefield{entrykey}}}%
-	%{%
-	%\ifthenelse{%
-		%\ifentrytype{software}\OR
-		%\ifentrytype{electronic}
-	%}{\addtocategory{software}{\thefield{entrykey}}}%
-	%{% else (default)
-		%\addtocategory{literature}{\thefield{entrykey}}}%
-%}}}
-
-
-
-\newcommand{\AssignBibCategory}[1]{y% argument 1: \thefield{entrykey} 
-\ifthenelse{%
+%Assign a given bibliography entry to one of the defined categories.
+\newcommand{\@AssignToBibCategory}[1]% argument 1: entry key 
+{\ifthenelse{%
 		\ifentrytype{online}\OR
-		\ifentrytype{www}
-	}{\addtocategory{online}{#1}}%
-	{%
-	\ifthenelse{%
+		\ifentrytype{www}}
+	{\addtocategory{online}{#1}}%
+{\ifthenelse{%
 		\ifentrytype{movie}\OR
 		\ifentrytype{video}\OR
 		\ifentrytype{music}\OR
 		\ifentrytype{audio}\OR
-		\ifentrytype{image}
-	}{\addtocategory{avmedia}{#1}}%
-	{%
-	\ifthenelse{%
+		\ifentrytype{image}}
+	{\addtocategory{avmedia}{#1}}%
+{\ifthenelse{%
 		\ifentrytype{software}\OR
-		\ifentrytype{electronic}
-	}{\addtocategory{software}{#1}}%
-	{% else (default)
-		\addtocategory{literature}{#1}}%
-}}
-}
+		\ifentrytype{electronic}}
+	{\addtocategory{software}{#1}}%
+	{\addtocategory{literature}{#1}}% else (default)
+}}}
 
-\newcommand{\nop}[1]{x}
-\AtEveryCitekey{\expandafter\nop\AssignBibCategory{\thefield{entrykey}}}
+%Hook provided by biblatex.
+\AtEveryCitekey{\@AssignToBibCategory{\thefield{entrykey}}}
 
 %This is only a wrapper to \addbibresource to allow the use
 %of the classic bibtex-workflow in the future.

--- a/hgbbib.sty
+++ b/hgbbib.sty
@@ -67,33 +67,10 @@
 
 \defbibheading{noheader}[]{}		% 'none' should be defined but isn't
 
-%% hook to add a given reference to its bibliography category
-%\AtEveryCitekey{%
-	%\ifthenelse{%
-		%\ifentrytype{online}\OR
-		%\ifentrytype{electronic}\OR
-		%\ifentrytype{www}
-	%}{%online
-		%\addtocategory{online}{\thefield{entrykey}}%
-	%}{%
-		%\ifthenelse{%
-			%\ifentrytype{movie}\OR
-			%\ifentrytype{video}\OR
-			%\ifentrytype{music}\OR
-			%\ifentrytype{audio}\OR
-			%\ifentrytype{software}
-		%}{%media
-			%\addtocategory{avmedia}{\thefield{entrykey}}%
-		%}{%literature
-			%\addtocategory{literature}{\thefield{entrykey}}%
-		%}%
-	%}%
-%}
 
 \AtEveryCitekey{%
 	\ifthenelse{%
 		\ifentrytype{online}\OR
-		\ifentrytype{electronic}\OR
 		\ifentrytype{www}
 	}{%online
 		\addtocategory{online}{\thefield{entrykey}}%
@@ -102,12 +79,14 @@
 			\ifentrytype{movie}\OR
 			\ifentrytype{video}\OR
 			\ifentrytype{music}\OR
-			\ifentrytype{audio}
+			\ifentrytype{audio}\OR
+			\ifentrytype{image}
 		}{%media
 			\addtocategory{avmedia}{\thefield{entrykey}}%
 		}{%
 		\ifthenelse{%
-		  \ifentrytype{software}
+		  \ifentrytype{software}\OR
+			\ifentrytype{electronic}
 		}{%software
 			\addtocategory{software}{\thefield{entrykey}}
 		}{%literature
@@ -169,3 +148,5 @@
 \DeclareBibliographyAlias{movie}{misc}
 \DeclareBibliographyAlias{audio}{misc}
 \DeclareBibliographyAlias{software}{misc}
+\DeclareBibliographyAlias{electronic}{misc}
+\DeclareBibliographyAlias{image}{misc}

--- a/hgbbib.sty
+++ b/hgbbib.sty
@@ -20,18 +20,21 @@
 \newcommand{\@bibtitle}{Quellenverzeichnis}
 \newcommand{\@bibtitleLiteratur}{Literatur}
 \newcommand{\@bibtitleAvmedia}{Filme und audiovisuelle Medien}
-\newcommand{\@bibtitleOnline}{Online-Quellen}	
+\newcommand{\@bibtitleOnline}{Online-Quellen}
+\newcommand{\@bibtitleSoftware}{Software}	
 
 \ifthenelse{\equal{\hgb@MainLanguage}{english}}{%
 	\renewcommand{\@bibtitle}{References}
 	\renewcommand{\@bibtitleLiteratur}{Literature}
 	\renewcommand{\@bibtitleAvmedia}{Films and audio-visual media}
 	\renewcommand{\@bibtitleOnline}{Online sources}	
+	\renewcommand{\@bibtitleSoftware}{Software}
 }{}
 
-%% categories for a split bibliography
+%% categories for a split bibliography (order of declaration is important!)
 \DeclareBibliographyCategory{literature}
 \DeclareBibliographyCategory{avmedia}
+\DeclareBibliographyCategory{software}
 \DeclareBibliographyCategory{online}
 
 %% headings for the bibliography categories
@@ -55,9 +58,38 @@
 	\addcontentsline{toc}{section}{\@bibtitleOnline}%
 }
 
+\defbibheading{software}{%
+	\pagebreak[3]%
+	\phantomsection%
+	\section*{\@bibtitleSoftware}%
+	\addcontentsline{toc}{section}{\@bibtitleSoftware}%
+}
+
 \defbibheading{noheader}[]{}		% 'none' should be defined but isn't
 
 %% hook to add a given reference to its bibliography category
+%\AtEveryCitekey{%
+	%\ifthenelse{%
+		%\ifentrytype{online}\OR
+		%\ifentrytype{electronic}\OR
+		%\ifentrytype{www}
+	%}{%online
+		%\addtocategory{online}{\thefield{entrykey}}%
+	%}{%
+		%\ifthenelse{%
+			%\ifentrytype{movie}\OR
+			%\ifentrytype{video}\OR
+			%\ifentrytype{music}\OR
+			%\ifentrytype{audio}\OR
+			%\ifentrytype{software}
+		%}{%media
+			%\addtocategory{avmedia}{\thefield{entrykey}}%
+		%}{%literature
+			%\addtocategory{literature}{\thefield{entrykey}}%
+		%}%
+	%}%
+%}
+
 \AtEveryCitekey{%
 	\ifthenelse{%
 		\ifentrytype{online}\OR
@@ -70,13 +102,17 @@
 			\ifentrytype{movie}\OR
 			\ifentrytype{video}\OR
 			\ifentrytype{music}\OR
-			\ifentrytype{audio}\OR
-			\ifentrytype{software}
+			\ifentrytype{audio}
 		}{%media
 			\addtocategory{avmedia}{\thefield{entrykey}}%
+		}{%
+		\ifthenelse{%
+		  \ifentrytype{software}
+		}{%software
+			\addtocategory{software}{\thefield{entrykey}}
 		}{%literature
 			\addtocategory{literature}{\thefield{entrykey}}%
-		}%
+		}}%
 	}%
 }
 

--- a/hgbbib.sty
+++ b/hgbbib.sty
@@ -68,32 +68,29 @@
 \defbibheading{noheader}[]{}		% 'none' should be defined but isn't
 
 
+%% hook to add a given reference to its bibliography category
 \AtEveryCitekey{%
 	\ifthenelse{%
 		\ifentrytype{online}\OR
 		\ifentrytype{www}
-	}{%online
-		\addtocategory{online}{\thefield{entrykey}}%
-	}{%
-		\ifthenelse{%
-			\ifentrytype{movie}\OR
-			\ifentrytype{video}\OR
-			\ifentrytype{music}\OR
-			\ifentrytype{audio}\OR
-			\ifentrytype{image}
-		}{%media
-			\addtocategory{avmedia}{\thefield{entrykey}}%
-		}{%
-		\ifthenelse{%
-		  \ifentrytype{software}\OR
-			\ifentrytype{electronic}
-		}{%software
-			\addtocategory{software}{\thefield{entrykey}}
-		}{%literature
-			\addtocategory{literature}{\thefield{entrykey}}%
-		}}%
-	}%
-}
+	}{\addtocategory{online}{\thefield{entrykey}}}%
+	{%
+	\ifthenelse{%
+		\ifentrytype{movie}\OR
+		\ifentrytype{video}\OR
+		\ifentrytype{music}\OR
+		\ifentrytype{audio}\OR
+		\ifentrytype{image}
+	}{\addtocategory{avmedia}{\thefield{entrykey}}}%
+	{%
+	\ifthenelse{%
+		\ifentrytype{software}\OR
+		\ifentrytype{electronic}
+	}{\addtocategory{software}{\thefield{entrykey}}}%
+	{% else (default)
+		\addtocategory{literature}{\thefield{entrykey}}}%
+}}}
+
 
 %This is only a wrapper to \addbibresource to allow the use
 %of the classic bibtex-workflow in the future.

--- a/hgbbib.sty
+++ b/hgbbib.sty
@@ -68,12 +68,38 @@
 \defbibheading{noheader}[]{}		% 'none' should be defined but isn't
 
 
-%% hook to add a given reference to its bibliography category
-\AtEveryCitekey{%
-	\ifthenelse{%
+
+
+% hook to add a given reference to its bibliography category
+%\AtEveryCitekey{%
+	%\ifthenelse{%
+		%\ifentrytype{online}\OR
+		%\ifentrytype{www}
+	%}{\addtocategory{online}{\thefield{entrykey}}}%
+	%{%
+	%\ifthenelse{%
+		%\ifentrytype{movie}\OR
+		%\ifentrytype{video}\OR
+		%\ifentrytype{music}\OR
+		%\ifentrytype{audio}\OR
+		%\ifentrytype{image}
+	%}{\addtocategory{avmedia}{\thefield{entrykey}}}%
+	%{%
+	%\ifthenelse{%
+		%\ifentrytype{software}\OR
+		%\ifentrytype{electronic}
+	%}{\addtocategory{software}{\thefield{entrykey}}}%
+	%{% else (default)
+		%\addtocategory{literature}{\thefield{entrykey}}}%
+%}}}
+
+
+
+\newcommand{\AssignBibCategory}[1]{y% argument 1: \thefield{entrykey} 
+\ifthenelse{%
 		\ifentrytype{online}\OR
 		\ifentrytype{www}
-	}{\addtocategory{online}{\thefield{entrykey}}}%
+	}{\addtocategory{online}{#1}}%
 	{%
 	\ifthenelse{%
 		\ifentrytype{movie}\OR
@@ -81,16 +107,19 @@
 		\ifentrytype{music}\OR
 		\ifentrytype{audio}\OR
 		\ifentrytype{image}
-	}{\addtocategory{avmedia}{\thefield{entrykey}}}%
+	}{\addtocategory{avmedia}{#1}}%
 	{%
 	\ifthenelse{%
 		\ifentrytype{software}\OR
 		\ifentrytype{electronic}
-	}{\addtocategory{software}{\thefield{entrykey}}}%
+	}{\addtocategory{software}{#1}}%
 	{% else (default)
-		\addtocategory{literature}{\thefield{entrykey}}}%
-}}}
+		\addtocategory{literature}{#1}}%
+}}
+}
 
+\newcommand{\nop}[1]{x}
+\AtEveryCitekey{\expandafter\nop\AssignBibCategory{\thefield{entrykey}}}
 
 %This is only a wrapper to \addbibresource to allow the use
 %of the classic bibtex-workflow in the future.

--- a/hgbbib.sty
+++ b/hgbbib.sty
@@ -19,14 +19,14 @@
 %% titles of reference section + 3 categories of references:
 \newcommand{\@bibtitle}{Quellenverzeichnis}
 \newcommand{\@bibtitleLiteratur}{Literatur}
-\newcommand{\@bibtitleAvmedia}{Filme und audiovisuelle Medien}
+\newcommand{\@bibtitleAvmedia}{Audiovisuelle Medien}
 \newcommand{\@bibtitleOnline}{Online-Quellen}
 \newcommand{\@bibtitleSoftware}{Software}	
 
 \ifthenelse{\equal{\hgb@MainLanguage}{english}}{%
 	\renewcommand{\@bibtitle}{References}
 	\renewcommand{\@bibtitleLiteratur}{Literature}
-	\renewcommand{\@bibtitleAvmedia}{Films and audio-visual media}
+	\renewcommand{\@bibtitleAvmedia}{Audio-visual media}
 	\renewcommand{\@bibtitleOnline}{Online sources}	
 	\renewcommand{\@bibtitleSoftware}{Software}
 }{}

--- a/references.bib
+++ b/references.bib
@@ -202,7 +202,7 @@
 	title={Autoconfiguration for {IP} Networking},
 	journal={IEEE Internet Computing},
 	volume={5},
-	issue={Mai/Juni},
+	issue={5/6},
 	year={2001},
 	pages={81-86},
 	hyphenation={english}

--- a/references.bib
+++ b/references.bib
@@ -228,7 +228,7 @@
 	hyphenation={english}
 }
 
-@online{HistoryOfComputers2008,
+@video{HistoryOfComputers2008,
 	title={History of Computers},
 	year={2008},
 	month={9},
@@ -274,6 +274,7 @@
 }
 
 @software{LegendOfZelda1998,
+	type={game},
 	author={Miyamoto, Shigeru and Aonuma, Eiji and Koizumi, Yoshiaki},
 	title={The Legend of Zelda: Ocarina of Time},
 	howpublished={N64-Spielmodul},
@@ -432,5 +433,11 @@
 	location={Reading, MA},
 	year={2011},
 	edition={4},
+	hyphenation={english}
+}
+
+@software{SpringFramework,
+	title={Spring Framework},
+	url={https://github.com/spring-projects/spring-framework},
 	hyphenation={english}
 }

--- a/references.bib
+++ b/references.bib
@@ -89,7 +89,7 @@
 	hyphenation={english},
 }
 
-@online{CocaCola1940,
+@image{CocaCola1940,
 	author={Wolcott, Marion Post},
 	title={Natchez, Miss.},
 	note={Library of Congress Prints and Photographs Division Washington, Farm Security Administration/Office of War Information Color Photographs},
@@ -274,7 +274,6 @@
 }
 
 @software{LegendOfZelda1998,
-	type={game},
 	author={Miyamoto, Shigeru and Aonuma, Eiji and Koizumi, Yoshiaki},
 	title={The Legend of Zelda: Ocarina of Time},
 	howpublished={N64-Spielmodul},

--- a/references.bib
+++ b/references.bib
@@ -440,3 +440,13 @@
 	url={https://github.com/spring-projects/spring-framework},
 	hyphenation={english}
 }
+
+@standard{W3C2017HTML52,
+  author={{World Wide Web Consortium}},
+  title={HTML 5.2},
+  titleaddon={W3C Candidate Recommendation},
+	date={2017-08-08},
+  url={https://www.w3.org/TR/html52/},
+	hyphenation={english}
+}
+

--- a/thesis_DE/chapters/literatur.tex
+++ b/thesis_DE/chapters/literatur.tex
@@ -253,15 +253,16 @@ Bei geteiltem Quellenverzeichnis werden die Überschriften der einzelnen Abschni
 \subsection{Kategorien von Quellenangaben}
 \label{sec:BibKategorien}
 
-Für geteilte Quellenverzeichnisse sind in dieser Vorlage folgende drei Kategorien vorgesehen
+Für geteilte Quellenverzeichnisse sind in dieser Vorlage folgende Kategorien vorgesehen
 (s.\ Tabelle \ref{tab:QuellenUndEintragstypen}):%
-\footnote{Diese sind in der Datei \nolinkurl{hgbthesis.cls} definiert.
+\footnote{Diese sind in der Datei \nolinkurl{hgbbib.sty} definiert.
 Allfällige Änderungen sowie die Definition zusätzlicher Kategorien sind 
 bei Bedarf relativ leicht möglich.}
 %
 \begin{description}
 	\item[\texttt{literature}] -- für alle Quellen, die in gedruckter Form vorliegen;
 	\item[\texttt{avmedia}] -- für Filme, audio-visuelle Medien und Computer Games (auf DVD, CD, \usw);
+	\item[\texttt{software}] -- für Softwareprodukte, APIs, Computer Games;
 	\item[\texttt{online}] -- für Werke, die \emph{ausschließlich} online verfügbar sind.
 \end{description}
 %
@@ -279,7 +280,7 @@ ausgegeben.
 \centering
 \begin{tabular}{llc}
 	\hline
-	Kategorie \emph{literature} & \texttt{@\emph{type}} & Seite\\
+	Kategorie \textbf{literature} & \texttt{@\emph{type}} & Seite\\
 	\hline
 	Buch (Textbuch, Monographie) & \texttt{@book} & \pageref{sec:@book}\\
 	Sammelband (Hrsg.\ + mehrere Autoren) & \texttt{@incollection} & \pageref{sec:@incollection} \\
@@ -291,18 +292,22 @@ ausgegeben.
 	Gesetzestext, Verordnung etc. & \texttt{@misc} & \pageref{sec:@misc}\\
 %
 	\hline
-	Kategorie \emph{avmedia} & \\
+	Kategorie \textbf{avmedia} & \\
 	\hline
 	Audio (CD) & \texttt{@audio} & \pageref{sec:@audio}\\
-	Video (auf VHS, DVD, Blu-ray Disk) & \texttt{@video} & \pageref{sec:@video}\\
+	Bild, Foto, Grafik & \texttt{@image} & \pageref{sec:@image}\\
+	Video (auf DVD, Blu-ray Disk, online) & \texttt{@video} & \pageref{sec:@video}\\
 	Film (Kino) & \texttt{@movie} & \pageref{sec:@movie}\\
-	Computer Game, Softwareprodukt & \texttt{@software} & \pageref{sec:@software}\\
 %
 	\hline
-	Kategorie \emph{online} & \\
+	Kategorie \textbf{software} & \\
 	\hline
-	Webseite, Wiki-Eintrag, Blog etc. & \texttt{@online} & \pageref{sec:@online-www}\\
-	Online-Video, Bild, Grafik & \texttt{@online} & \pageref{sec:@online-video}\\
+	Softwareprodukt oder -projekt, Computer Game & \texttt{@software} & \pageref{sec:@software}\\
+%
+	\hline
+	Kategorie \textbf{online} & \\
+	\hline
+	Webseite, Wiki-Eintrag, Blog etc. & \texttt{@online} & \pageref{sec:@online-www}
 \end{tabular}
 \end{table}
 
@@ -653,13 +658,57 @@ Hier ein Beispiel für die Spezifikation einer Audio-CD:
 \end{GenericCode}
 \item[\cite{Zappa1995}] \fullcite{Zappa1995}
 \end{itemize}
-
+%
 Anstelle von \verb!howpublished={Audio-CD}! könnte auch \verb!type={audiocd}! verwendet werden.
+
+
+\subsubsection{\texttt{@image}}
+\label{sec:@image}
+
+Das nachfolgende Beispiel zeigt den Verweis auf ein digital verfügbares Foto,
+das auch in Abb.\ \ref{fig:CocaCola} verwendet wird:
+%
+\begin{itemize}
+\item[] 
+\begin{GenericCode}[numbers=none]
+@image{CocaCola1940,
+  author={Wolcott, Marion Post},
+	title={Natchez, Miss.},
+	note={Library of Congress Prints and Photographs Division Washington, Farm Security Administration/Office of War Information Color Photographs},
+	year={1940},
+	month={8},
+	url={http://www.loc.gov/pictures/item/fsa1992000140/PP/},
+  hyphenation={english}
+ }
+\end{GenericCode}
+\item[\cite{CocaCola1940}] \fullcite{CocaCola1940}
+\end{itemize}
+
+
+
 
 
 \subsubsection{\texttt{@video}}
 \label{sec:@video}
-Hier ein Beispiel für die Spezifikation einer DVD-Edition:
+
+Das nachfolgende Beispiel zeigt den Verweis auf ein YouTube-Video:
+%
+\begin{itemize}
+\item[]
+\begin{GenericCode}[numbers=none]
+@video{HistoryOfComputers2008,
+  title={History of Computers},
+	url={http://www.youtube.com/watch?v=LvKxJ3bQRKE},
+  year={2008},
+  month={9},
+  hyphenation={english}
+}
+\end{GenericCode}
+\item[\cite{HistoryOfComputers2008}] \fullcite{HistoryOfComputers2008}
+\end{itemize}
+
+\noindent
+Hier ein Beispiel für den Verweis auf eine DVD-Edition:
 %
 \begin{itemize}
 \item[] 
@@ -683,22 +732,6 @@ Falls kein eindeutiger Autor namhaft gemacht werden kann, lässt man das
 \texttt{author}-Feld weg und verpackt die entsprechenden Angaben im \texttt{note}-Feld, wie im nachfolgenden Beispiel gezeigt.
 
 
-\paragraph{Beispiel: YouTube-Video} 
-%\label{sec:@online-video}
-%
-\begin{itemize}
-\item[]
-\begin{GenericCode}[numbers=none]
-@video{HistoryOfComputers2008,
-  title={History of Computers},
-	url={http://www.youtube.com/watch?v=LvKxJ3bQRKE},
-  year={2008},
-  month={9},
-  hyphenation={english}
-}
-\end{GenericCode}
-\item[\cite{HistoryOfComputers2008}] \fullcite{HistoryOfComputers2008}
-\end{itemize}
 
 
 \subsubsection{\texttt{@movie}}
@@ -729,8 +762,26 @@ Die Angabe \verb!howpublished={Film}! ist hier sinnvoll, um die Verwechslung
 mit einem (möglicherweise gleichnamigen) Buch auszuschließen.
 
 
-\subsubsection{\texttt{@software}}
-\label{sec:@software}
+
+\subsubsection{Zeitangaben zu Musikaufnahmen und Filmen} 
+
+Einen Verweis auf eine bestimmten Stelle in einem Musikstück oder Film kann man 
+ähnlich ausführen wie die Seitenangabe in einem Druckwerk.
+Besonders legendär (und häufig parodiert) ist beispielsweise die Duschszene
+in \emph{Psycho} \cite[T=00:32:10]{Psycho1960}.
+Alternativ zur simplen Zeitangabe "`T=\emph{hh}:\emph{mm}:\emph{ss}"' 
+könnte man eine bestimmte Stelle auch auf den Frame genau durch 
+den zugehörigen \emph{Timecode} "`TC=\emph{hh:mm:ss:ff}"' angeben, 
+\zB\ \cite[TC=00:32:10:12]{Psycho1960} für Frame \emph{ff}=12.
+
+
+
+\subsection{Software (\texttt{@software})}
+\label{sec:KategorieSoftware}
+
+%\subsubsection{\texttt{@software}}
+%\label{sec:@software}
+
 Dieser Eintragstyp ist insbesondere für Computerspiele geeignet (in Ermangelung
 eines eigenen Eintragstyps).
 %
@@ -749,20 +800,20 @@ eines eigenen Eintragstyps).
 \item[\cite{LegendOfZelda1998}] \fullcite{LegendOfZelda1998}
 \end{itemize}
 
-
-Spring Framework: \cite{SpringFramework}
-
-
-\subsubsection{Zeitangaben zu Musikaufnahmen und Filmen} 
-
-Einen Verweis auf eine bestimmten Stelle in einem Musikstück oder Film kann man 
-ähnlich ausführen wie die Seitenangabe in einem Druckwerk.
-Besonders legendär (und häufig parodiert) ist beispielsweise die Duschszene
-in \emph{Psycho} \cite[T=00:32:10]{Psycho1960}.
-Alternativ zur simplen Zeitangabe "`T=\emph{hh}:\emph{mm}:\emph{ss}"' 
-könnte man eine bestimmte Stelle auch auf den Frame genau durch 
-den zugehörigen \emph{Timecode} "`TC=\emph{hh:mm:ss:ff}"' angeben, 
-\zB\ \cite[TC=00:32:10:12]{Psycho1960} für Frame \emph{ff}=12.
+\noindent
+Nachfolgend ein Beispiel für den Verweis auf ein typisches Software-Projekt:
+%
+\begin{itemize}
+\item[] 
+\begin{GenericCode}[numbers=none]
+@software{SpringFramework,
+	title={Spring Framework},
+	url={https://github.com/spring-projects/spring-framework},
+	hyphenation={english}
+}
+\end{GenericCode}
+\item[\cite{SpringFramework}] \fullcite{SpringFramework}
+\end{itemize}
 
 
 
@@ -785,8 +836,7 @@ Bei Verweisen auf Online-Resourcen sind grundsätzlich drei Fälle zu unterschei
 	aber \emph{nicht} "`online"' und es genügt, ggfs.\ den zugehörigen Link im 
 	\texttt{url}-Feld anzugeben, das bei jedem Eintragstyp zulässig ist.
 \item[C.] Es handelt sich im weitesten Sinn um ein Werk, das aber 
-	\emph{ausschließlich} online verfügbar ist, wie \zB\ ein Wiki-Eintrag, 
-	ein digitales Bild,	eine Software, ein YouTube-Video oder ein Blog-Eintrag.
+	\emph{ausschließlich} online verfügbar ist, wie \zB\ ein Wiki oder Blog-Eintrag.
 	Die Kategorie \emph{online} ist genau (und \emph{nur}) für diese 
 	Art von Quellen vorgesehen.
 \end{itemize}
@@ -831,38 +881,38 @@ zumindest einen sinnvollen \emph{Titel} (\texttt{title}) angeben,
 der für die Sortierung im Quellenverzeichnis verwendet wird.
 
 
-\subsubsection{Beispiel: Bildquelle}
-
-In Abbildungen wird sehr häufig fremdes Bildmaterial verwendet, dessen Herkunft natürlich 
-in jedem Fall angegeben werden sollte. Die Angabe von URLs unmittelbar in den Captions von Abbildungen
-ist problematisch, weil sie meistens für das Schriftbild ziemlich störend sind.
-Einfacher ist es, auch einzelne Bilder und Grafiken ins Quellenverzeichnis aufzunehmen und
-wie üblich mit dem \verb!\cite{..}! Kommando darauf zu verweisen.
-Beispiele dazu sind die Angaben zu Abb.\ \ref{fig:CocaCola}--\ref{fig:ibm360}.
+%\subsubsection{Beispiel: Bildquelle}
 %
-\begin{itemize}
-\item[]
-\begin{GenericCode}[numbers=none]
-@online{IBM360,
-	title={Mainframes},
-  url={http://www.plyojump.com/classes/mainframe_era.php}
-}
-\end{GenericCode}
-\item[\cite{IBM360}] \fullcite{IBM360}
-\end{itemize}
+%In Abbildungen wird sehr häufig fremdes Bildmaterial verwendet, dessen Herkunft natürlich 
+%in jedem Fall angegeben werden sollte. Die Angabe von URLs unmittelbar in den Captions von Abbildungen
+%ist problematisch, weil sie meistens für das Schriftbild ziemlich störend sind.
+%Einfacher ist es, auch einzelne Bilder und Grafiken ins Quellenverzeichnis aufzunehmen und
+%wie üblich mit dem \verb!\cite{..}! Kommando darauf zu verweisen.
+%Beispiele dazu sind die Angaben zu Abb.\ \ref{fig:CocaCola}--\ref{fig:ibm360}.
+%%
+%\begin{itemize}
+%\item[]
+%\begin{GenericCode}[numbers=none]
+%@online{IBM360,
+	%title={Mainframes},
+  %url={http://www.plyojump.com/classes/mainframe_era.php}
+%}
+%\end{GenericCode}
+%\item[\cite{IBM360}] \fullcite{IBM360}
+%\end{itemize}
 
-\subsection{Elektronische Datenträger als Ergänzung zur Arbeit}
-
-Wird der Abschlussarbeit ein elektronischer Datenträger (CD-ROM, DVD, USB-Stick
-etc.) beigelegt, empfiehlt sich die angeführten Webseiten in
-elektronischer Form (vorzugsweise als PDF-Da\-tei\-en) abzulegen
-und die zugehörige Quelle im Quellenverzeichnis mit einem 
-entsprechenden Verweis im \texttt{note}-Feld -- \zB\
-"`Kopie auf USB-Stick (Datei \nolinkurl{xyz.pdf})"' --
-zu versehen.
-Für die Angabe von solchen Dateinamen, die nicht als Online-Link
-zu öffnen sind, ist übrigens die Verwendung von 
-\verb!\nolinkurl{...}! anstelle von \verb!\url{...}! zu empfehlen.
+%\subsection{Elektronische Datenträger als Ergänzung zur Arbeit}
+%
+%Wird der Abschlussarbeit ein elektronischer Datenträger (CD-ROM, DVD, USB-Stick
+%etc.) beigelegt, empfiehlt sich die angeführten Webseiten in
+%elektronischer Form (vorzugsweise als PDF-Da\-tei\-en) abzulegen
+%und die zugehörige Quelle im Quellenverzeichnis mit einem 
+%entsprechenden Verweis im \texttt{note}-Feld -- \zB\
+%"`Kopie auf USB-Stick (Datei \nolinkurl{xyz.pdf})"' --
+%zu versehen.
+%Für die Angabe von solchen Dateinamen, die nicht als Online-Link
+%zu öffnen sind, ist übrigens die Verwendung von 
+%\verb!\nolinkurl{...}! anstelle von \verb!\url{...}! zu empfehlen.
 
 
 \subsection{Tipps zur Erstellung von BibTeX-Dateien}

--- a/thesis_DE/chapters/literatur.tex
+++ b/thesis_DE/chapters/literatur.tex
@@ -242,11 +242,6 @@ Dabei sind zwei Varianten möglich:
 \item[\texttt{{\bs}MakeBibliography[nosplit]}] ~ \newline
    Erzeugt ein traditionelles \emph{einteiliges} Quellenverzeichnis. 
 \end{description}
-%
-Die Überschrift \texttt{\emph{title}} scheint in beiden Fällen ohne Nummerierung 
-im Inhaltsverzeichnis auf (auf \texttt{chapter}-Ebene).
-Bei geteiltem Quellenverzeichnis werden die Überschriften der einzelnen Abschnitte auf 
-\texttt{section}-Ebene eingetragen.
 
 
 \subsection{Kategorien von Quellenangaben}
@@ -258,20 +253,20 @@ Für geteilte Quellenverzeichnisse sind in dieser Vorlage folgende Kategorien vo
 Allfällige Änderungen sowie die Definition zusätzlicher Kategorien sind 
 bei Bedarf relativ leicht möglich.}
 %
-\begin{description}
-	\item[\textsf{literature}] -- für alle Quellen, die in gedruckter Form vorliegen;
-	\item[\textsf{avmedia}] -- für Filme, audio-visuelle Medien (auf DVD, CD, \usw);
-	\item[\textsf{software}] -- für Softwareprodukte, APIs, Computer Games;
-	\item[\textsf{online}] -- für Werke, die \emph{ausschließlich} online verfügbar sind.
-\end{description}
+\begin{itemize}
+	\item[] \textsf{literature} -- für klassische Publikationen, die gedruckt oder online vorliegen;
+	\item[] \textsf{avmedia} -- für Filme, audio-visuelle Medien (auf DVD, CD, \usw);
+	\item[] \textsf{software} -- für Softwareprodukte, APIs, Computer Games;
+	\item[] \textsf{online} -- für Artefakte, die \emph{ausschließlich} online verfügbar sind.
+\end{itemize}
 %
 Jedes Quellenobjekt wird aufgrund des angegebenen BibTeX-Eintragtyps 
 (\texttt{@\emph{type}}) automatisch einer dieser Kategorien 
 zugeordnet (s.\ Tabelle~\ref{tab:BibKategorien}).
 Angeführt sind hier nur die wichtigsten Eintragstypen, die allerdings die meisten
 Fälle in der Praxis abdecken sollten und nachfolgend durch Beispiele erläutert sind.
-Alle nicht explizit angegebenen Einträge werden grundsätzlich in der Kategorie \textsf{literature} 
-ausgegeben.
+Alle nicht explizit angegebenen Einträge werden grundsätzlich der Kategorie \textsf{literature} 
+zugeordnet.
 
 \begin{table}
 \caption{Definierte Kategorien von Quellen und empfohlene BibTeX-Eintragstypen.}
@@ -287,7 +282,8 @@ ausgegeben.
 	Beitrag in Zeitschrift, Journal & \texttt{@article} & \pageref{sec:@article}\\
 	Bachelor-, Master-, Diplomarbeit, Dissertation & \texttt{@thesis} & \pageref{sec:@thesis}\\
 	Technischer Bericht, Laborbericht & \texttt{@techreport} & \pageref{sec:@techreport}\\
-	Handbuch, Produktbeschreibung, Norm & \texttt{@manual} & \pageref{sec:@manual}\\
+	Handbuch, Produktbeschreibung & \texttt{@manual} & \pageref{sec:@manual}\\
+	Norm & \texttt{@standard} & \pageref{sec:@standard}\\
 	Gesetzestext, Verordnung etc. & \texttt{@misc} & \pageref{sec:@misc}\\
 %
 	\hline
@@ -331,6 +327,7 @@ Grau gekennzeichnete Elemente sind Synonyme für die jeweils darüber stehenden 
 	\texttt{@thesis}        & \texttt{@software}             & &  \\
 	\texttt{@techreport}    &  & &  \\
 	\texttt{@manual}        &  & &  \\
+	\texttt{@standard}        &  & &  \\
 	\texttt{@misc}          &  & &  \\
 	\ldots                  &  & &  \\
 	\hline
@@ -573,7 +570,7 @@ Adresse angegeben wird. Sinnvollerweise wird auch der zugehörige URL angegeben,
 
 \subsubsection{\texttt{@manual}}
 \label{sec:@manual}
-Dieser Publikationstyp bietet sich jegliche Art von technischer oder anderer Dokumentation an, wie etwa Produktbeschreibungen von Herstellern, Anleitungen, Präsentationen, Normen, White Papers \usw Die Dokumentation muss dabei nicht zwingend gedruckt existieren.
+Dieser Publikationstyp bietet sich jegliche Art von technischer oder anderer Dokumentation an, wie etwa Produktbeschreibungen von Herstellern, Anleitungen, Präsentationen, White Papers \usw Die Dokumentation muss dabei nicht zwingend gedruckt existieren.
 %
 \begin{itemize}
 \item[]
@@ -591,8 +588,37 @@ Dieser Publikationstyp bietet sich jegliche Art von technischer oder anderer Dok
 \item[\cite{Mittelbach2016}] \fullcite{Mittelbach2016}
 \end{itemize}
 %
-Oft wird bei derartigen Dokumenten kein Autor genannt. Dann wird der Name des \emph{Unternehmens} oder der \emph{Institution} im \texttt{author}-Feld angegeben, allerdings innerhalb einer \textbf{zusätzlichen Klammer} \texttt{\{..\}}, damit das Argument nicht fälschlicherweise als \emph{Vorname}+\emph{Nachname} interpretiert wird.%
+Oft wird bei derartigen Dokumenten kein Autor genannt. Dann wird der Name des \emph{Unternehmens} oder der \emph{Institution} im \texttt{author}-Feld angegeben, allerdings innerhalb einer \textbf{zusätzlichen Klammer} \texttt{\{..\}}, damit das Argument nicht fälschlicherweise als \emph{Vornamen} + \emph{Nachname} interpretiert wird.%
 \footnote{Im Unterschied zu BibTeX wird in \texttt{biblatex} bei \texttt{@manual}-Einträgen das Feld \texttt{organization} nicht als Ersatz für \texttt{author} akzeptiert.}
+Dieser Trick wird \ua\ im nächsten Beispiel verwendet.
+
+
+%%------------------------------------------------------
+
+\subsubsection{\texttt{@standard}}
+\label{sec:@standard}
+
+
+Verweise auf Normen (\emph{standards}) werden in \texttt{biblatex} durch den Typ \texttt{@standard}
+unterstützt. Hier ein typisches Beispiel:
+%
+\begin{itemize}
+\item[]
+\begin{GenericCode}[numbers=none]
+@standard{W3C2017HTML52,
+  author={{World Wide Web Consortium}},
+  title={HTML 5.2},
+  titleaddon={W3C Candidate Recommendation},
+	date={2017-08-08},
+  url={https://www.w3.org/TR/html52/},
+	hyphenation={english}
+}
+\end{GenericCode}
+\item[\cite{W3C2017HTML52}] \fullcite{W3C2017HTML52}
+\end{itemize}
+%
+
+
 
 %%------------------------------------------------------
 
@@ -994,7 +1020,7 @@ Groß-/Kleinschreibung und Satzzeichen in allen  Einträgen überprüfen und ggf
 Bücher: Verlagsnamen und Verlagsort auf Vollständigkeit, Konsistenz und allfällige
 Redundanzen überprüfen.
 \item
-Alle URLs und DOIs etc.\ \emph{weglassen}, sofern sie nicht essentiell sind! Das gilt insbesondere
+Alle URLs und DOIs etc.\ \emph{weglassen}, wenn sie nicht unbedingt notwendig sind! Das gilt insbesondere
 für Bücher und Konferenzbeiträge.
 \item
 Journal-Beiträge: Den Namen des Journals immer vollständig ausschreiben, \zB\

--- a/thesis_DE/chapters/literatur.tex
+++ b/thesis_DE/chapters/literatur.tex
@@ -279,7 +279,7 @@ ausgegeben.
 \centering
 \begin{tabular}{llc}
 	\hline
-	Kategorie \textbf{literature} & \texttt{@\emph{type}} & Seite\\
+	Kat.\ \textbf{literature} & Typ & Seite\\
 	\hline
 	Buch (Textbuch, Monographie) & \texttt{@book} & \pageref{sec:@book}\\
 	Sammelband (Hrsg.\ + mehrere Autoren) & \texttt{@incollection} & \pageref{sec:@incollection} \\

--- a/thesis_DE/chapters/literatur.tex
+++ b/thesis_DE/chapters/literatur.tex
@@ -259,27 +259,27 @@ Allfällige Änderungen sowie die Definition zusätzlicher Kategorien sind
 bei Bedarf relativ leicht möglich.}
 %
 \begin{description}
-	\item[\texttt{literature}] -- für alle Quellen, die in gedruckter Form vorliegen;
-	\item[\texttt{avmedia}] -- für Filme, audio-visuelle Medien und Computer Games (auf DVD, CD, \usw);
-	\item[\texttt{software}] -- für Softwareprodukte, APIs, Computer Games;
-	\item[\texttt{online}] -- für Werke, die \emph{ausschließlich} online verfügbar sind.
+	\item[\textsf{literature}] -- für alle Quellen, die in gedruckter Form vorliegen;
+	\item[\textsf{avmedia}] -- für Filme, audio-visuelle Medien (auf DVD, CD, \usw);
+	\item[\textsf{software}] -- für Softwareprodukte, APIs, Computer Games;
+	\item[\textsf{online}] -- für Werke, die \emph{ausschließlich} online verfügbar sind.
 \end{description}
 %
 Jedes Quellenobjekt wird aufgrund des angegebenen BibTeX-Eintragtyps 
-\texttt{@\emph{type}} automatisch einer dieser Kategorien 
+(\texttt{@\emph{type}}) automatisch einer dieser Kategorien 
 zugeordnet (s.\ Tabelle~\ref{tab:BibKategorien}).
 Angeführt sind hier nur die wichtigsten Eintragstypen, die allerdings die meisten
 Fälle in der Praxis abdecken sollten und nachfolgend durch Beispiele erläutert sind.
-Alle nicht explizit angegebenen Einträge werden grundsätzlich in der Kategorie \emph{literature} 
+Alle nicht explizit angegebenen Einträge werden grundsätzlich in der Kategorie \textsf{literature} 
 ausgegeben.
 
 \begin{table}
-\caption{Quellenarten und empfohlene BibTeX-Eintragstypen.}
+\caption{Definierte Kategorien von Quellen und empfohlene BibTeX-Eintragstypen.}
 \label{tab:QuellenUndEintragstypen}
 \centering
 \begin{tabular}{llc}
 	\hline
-	Kat.\ \textbf{literature} & Typ & Seite\\
+	\emph{Literatur} (\textsf{literature}) & Typ & Seite\\
 	\hline
 	Buch (Textbuch, Monographie) & \texttt{@book} & \pageref{sec:@book}\\
 	Sammelband (Hrsg.\ + mehrere Autoren) & \texttt{@incollection} & \pageref{sec:@incollection} \\
@@ -291,7 +291,7 @@ ausgegeben.
 	Gesetzestext, Verordnung etc. & \texttt{@misc} & \pageref{sec:@misc}\\
 %
 	\hline
-	Kategorie \textbf{avmedia} & \\
+	\emph{Audiovisuelle Medien} (\textsf{avmedia}) & \\
 	\hline
 	Audio (CD) & \texttt{@audio} & \pageref{sec:@audio}\\
 	Bild, Foto, Grafik & \texttt{@image} & \pageref{sec:@image}\\
@@ -299,12 +299,13 @@ ausgegeben.
 	Film (Kino) & \texttt{@movie} & \pageref{sec:@movie}\\
 %
 	\hline
-	Kategorie \textbf{software} & \\
+	\emph{Software} (\textsf{software}) & \\
 	\hline
-	Softwareprodukt oder -projekt, Computer Game & \texttt{@software} & \pageref{sec:@software}\\
+	Softwareprodukt oder -projekt & \texttt{@software} & \pageref{sec:@software}\\
+	Computer Game & \texttt{@software} & \pageref{sec:@software}\\
 %
 	\hline
-	Kategorie \textbf{online} & \\
+	\emph{Online-Quellen} (\textsf{online}) & \\
 	\hline
 	Webseite, Wiki-Eintrag, Blog etc. & \texttt{@online} & \pageref{sec:@online-www}
 \end{tabular}
@@ -319,26 +320,26 @@ Grau gekennzeichnete Elemente sind Synonyme für die jeweils darüber stehenden 
 \label{tab:BibKategorien}
 \centering
 \definecolor{midgray}{gray}{0.5}
-\setlength{\tabcolsep}{6mm}
-\begin{tabular}{lll}
-	\emph{literature} & \emph{avmedia} & \emph{online} \\
+\setlength{\tabcolsep}{4mm}
+\begin{tabular}{llll}
+	\textsf{literature} & \textsf{avmedia} & \textsf{software} & \textsf{online} \\
 	\hline
-	\texttt{@book}          & \texttt{@audio}                & \texttt{@online} \\
-	\texttt{@incollection}  & \texttt{\color{midgray}@music} & \texttt{\color{midgray}@electronic} \\
-	\texttt{@inproceedings} & \texttt{@video}                & \texttt{\color{midgray}@www} \\
-	\texttt{@article}       & \texttt{@movie}                &  \\
-	\texttt{@thesis}        & \texttt{@software}             &  \\
-	\texttt{@techreport}    &  &  \\
-	\texttt{@manual}        &  &  \\
-	\texttt{@misc}          &  &  \\
-	\ldots                  &  &  \\
+	\texttt{@book}          & \texttt{@audio}                & \texttt{@software} & \texttt{@online} \\
+	\texttt{@incollection}  & \texttt{\color{midgray}@music} & & \texttt{\color{midgray}@electronic} \\
+	\texttt{@inproceedings} & \texttt{@video}                & & \texttt{\color{midgray}@www} \\
+	\texttt{@article}       & \texttt{@movie}                & &  \\
+	\texttt{@thesis}        & \texttt{@software}             & &  \\
+	\texttt{@techreport}    &  & &  \\
+	\texttt{@manual}        &  & &  \\
+	\texttt{@misc}          &  & &  \\
+	\ldots                  &  & &  \\
 	\hline
 \end{tabular}
 \end{table}
 
 %%------------------------------------------------------
 
-\subsection{Gedruckte Quellen (\emph{literature})}
+\subsection{Gedruckte Quellen (\textsf{literature})}
 \label{sec:KategorieLiterature}
 
 Diese Kategorie umfasst alle Werke, die in gedruckter Form publiziert wurden,
@@ -460,7 +461,7 @@ zu vermeiden.
 %
 \emph{Hinweis:} Die Angabe einer Ausgabe für \emph{mehrere} Monate ist in \texttt{biblatex} nicht mehr
 über das Feld \texttt{month} möglich, denn dieses darf nur mehr \emph{einen} Wert enthalten.
-In diesem Fall kann jedoch einfach das \texttt{issue}-Feld verwendet (\zB\ \verb!issue={Mai/Juni}!
+In diesem Fall kann jedoch einfach das \texttt{issue}-Feld verwendet (\zB\ \texttt{issue=\{5/6\}}
 im BibTeX-Eintrag zu \cite{Guttman2001}) und das \texttt{number}-Feld weggelassen werden.
 
 %%------------------------------------------------------
@@ -622,7 +623,7 @@ angegeben werden kann. Das folgende Beispiel zeigt die Anwendung für einen Gese
 \end{itemize}
 
 
-\subsection{Filme und audio-visuelle Medien (\emph{avmedia})}
+\subsection{Filme und audio-visuelle Medien (\textsf{avmedia})}
 \label{sec:KategorieAvmedia}
 Diese Kategorie ist dazu vorgesehen, audio-visuelle Produktionen wie Filme, 
 Tonaufzeichnungen, Audio-CDs, DVDs, VHS-Kassetten \usw\ zu erfassen.
@@ -775,7 +776,7 @@ den zugehörigen \emph{Timecode} "`TC=\emph{hh:mm:ss:ff}"' angeben,
 
 
 
-\subsection{Software (\texttt{@software})}
+\subsection{Software (\textsf{software})}
 \label{sec:@software}
 
 
@@ -815,7 +816,7 @@ Nachfolgend ein Beispiel für den Verweis auf ein typisches Software-Projekt:
 
 
 
-\subsection{Online-Quellen (\emph{online})}
+\subsection{Online-Quellen (\textsf{online})}
 \label{sec:KategorieOnline}
 
 Bei Verweisen auf Online-Resourcen sind grundsätzlich drei Fälle zu unterscheiden:

--- a/thesis_DE/chapters/literatur.tex
+++ b/thesis_DE/chapters/literatur.tex
@@ -236,12 +236,11 @@ besorgt die Ausgabe des Quellenverzeichnisses, hier mit dem Titel "`Quellenverze
 Dabei sind zwei Varianten möglich:
 %
 \begin{description}
-\item[\texttt{{\bs}MakeBibliography\{\emph{title}\}}] ~ \newline
-   Erzeugt ein in mehrere \emph{Kategorien} (s.\ Abschnitt \ref{sec:BibKategorien}) geteiltes Quellenverzeichnis 
-   mit der Hauptüberschrift \texttt{title}. Diese Variante wird im vorliegenden Dokument verwendet.
-\item[\texttt{{\bs}MakeBibliography[nosplit]\{\emph{title}\}}] ~ \newline
-   Erzeugt ein traditionelles \emph{einteiliges} Quellenverzeichnis mit der
-   Überschrift \texttt{title}. 
+\item[\texttt{{\bs}MakeBibliography}] ~ \newline
+   Erzeugt ein in mehrere \emph{Kategorien} (s.\ Abschnitt \ref{sec:BibKategorien}) geteiltes Quellenverzeichnis. 
+	 Diese Variante wird im vorliegenden Dokument verwendet.
+\item[\texttt{{\bs}MakeBibliography[nosplit]}] ~ \newline
+   Erzeugt ein traditionelles \emph{einteiliges} Quellenverzeichnis. 
 \end{description}
 %
 Die Überschrift \texttt{\emph{title}} scheint in beiden Fällen ohne Nummerierung 
@@ -777,10 +776,9 @@ den zugehörigen \emph{Timecode} "`TC=\emph{hh:mm:ss:ff}"' angeben,
 
 
 \subsection{Software (\texttt{@software})}
-\label{sec:KategorieSoftware}
+\label{sec:@software}
 
-%\subsubsection{\texttt{@software}}
-%\label{sec:@software}
+
 
 Dieser Eintragstyp ist insbesondere für Computerspiele geeignet (in Ermangelung
 eines eigenen Eintragstyps).

--- a/thesis_DE/chapters/literatur.tex
+++ b/thesis_DE/chapters/literatur.tex
@@ -683,6 +683,24 @@ Falls kein eindeutiger Autor namhaft gemacht werden kann, lässt man das
 \texttt{author}-Feld weg und verpackt die entsprechenden Angaben im \texttt{note}-Feld, wie im nachfolgenden Beispiel gezeigt.
 
 
+\paragraph{Beispiel: YouTube-Video} 
+%\label{sec:@online-video}
+%
+\begin{itemize}
+\item[]
+\begin{GenericCode}[numbers=none]
+@video{HistoryOfComputers2008,
+  title={History of Computers},
+	url={http://www.youtube.com/watch?v=LvKxJ3bQRKE},
+  year={2008},
+  month={9},
+  hyphenation={english}
+}
+\end{GenericCode}
+\item[\cite{HistoryOfComputers2008}] \fullcite{HistoryOfComputers2008}
+\end{itemize}
+
+
 \subsubsection{\texttt{@movie}}
 \label{sec:@movie}
 Dieser Eintragstyp ist für Filme reserviert. 
@@ -731,6 +749,8 @@ eines eigenen Eintragstyps).
 \item[\cite{LegendOfZelda1998}] \fullcite{LegendOfZelda1998}
 \end{itemize}
 
+
+Spring Framework: \cite{SpringFramework}
 
 
 \subsubsection{Zeitangaben zu Musikaufnahmen und Filmen} 
@@ -801,22 +821,7 @@ Durch die (optionale) Angabe von \texttt{urldate} (im \texttt{YYYY-MM-DD} Format
 die Information eingefügt, wann das Online-Dokument tatsächlich eingesehen wurde.
 
 
-\subsubsection{Beispiel: online Video} 
-\label{sec:@online-video}
-%
-\begin{itemize}
-\item[]
-\begin{GenericCode}[numbers=none]
-@online{HistoryOfComputers2008,
-  title={History of Computers},
-	url={http://www.youtube.com/watch?v=LvKxJ3bQRKE},
-  year={2008},
-  month={9},
-  hyphenation={english}
-}
-\end{GenericCode}
-\item[\cite{HistoryOfComputers2008}] \fullcite{HistoryOfComputers2008}
-\end{itemize}
+
 
 \noindent\textbf{Hinweis:}
 Technisch ist bei Online-Quellen nur das Feld \texttt{url} erforderlich,


### PR DESCRIPTION
This update incurs the following changes:

- Adds the new ``software`` reference category, intended for software products, APIs, computer games etc. These references are listed together in a separate section if a split bibliography is used (default).
- Use of the ``@image`` biblatex type for sample images.
- Adds a new example using the ``@standard`` biblatex type (as proposed by @hochleitner).
- Some related fixes in the instructions.
