### PR TITLE
Add CHANGELOG.md based on existing git tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,48 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/)
+and this project DOES NOT adhere to [Semantic Versioning](http://semver.org/).
+
+## [unreleased]
+
+## [2017/11/05]
+
+## Added
+- Automatic building with `make`.
+- The bundle is distributed by CTAN as package [hagenberg-thesis](https://ctan.org/pkg/hagenberg-thesis).
+
+## Changed
+- Restructured setup for CTAN distribution
+- Original `.cls` and `.sty` files are now stored in `common/`.
+- Sample LaTeX documents are stored in `examples/`, with individual ZIP files for "single-click authoring" in Overleaf. Git submodules not needed any longer.
+
+## [2017/10/16]
+
+### Added
+- new classes `hgbreport` and `hgbarticle`
+- bibliography categorization
+- new bibliography examples
+
+### Changed
+- PDF inclusion mechanism
+
+## [2017/02/28]
+
+### Added
+- new and unified English commands for the front matter
+
+### Changed
+- headings in sans serif fonts
+- smaller page margins
+- two separate versions for German and English (the latter still being empty but ready to use)
+
+## 2016/06/11
+
+This is the first release on GitHub. Future versions will now be published on this repository.
+This version has also been ported to Overleaf for online editing.
+
+[Unreleased]: https://github.com/Digital-Media/HagenbergThesis/compare/2017/11/05...master
+[2017/11/05]: https://github.com/Digital-Media/HagenbergThesis/compare/2017/10/16...2017/11/05
+[2017/10/16]: https://github.com/Digital-Media/HagenbergThesis/compare/2017/02/28...2017/10/16
+[2017/02/28]: https://github.com/Digital-Media/HagenbergThesis/compare/2016/06/11...2017/02/28

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,15 +4,38 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project DOES NOT adhere to [Semantic Versioning](http://semver.org/).
 
-## [unreleased]
+## [Unreleased]
+
+### Added
+
+- Added (experimental) support for "smart quotes" using the csquotes package. To activate, pass the option smartquotes to any of the hgb document classes. See examples/HgbThesisTutorial-smartquotes for details.
+
+## [2018/11/28]
+
+### Added
+- Added patent references.
+- Added setup for biblatex's \cites command (for multiple citations with supplementary texts).
+- Added a new macro \citenobr (in hgbbib.sty) to create citations with no "backref" entry in the bibliography.
+- Added new macro \mcite for multiple citations with description texts (replacement for biblatex's \cites macro): \mcite inserts a semicolon as delimiter between each entry, while ordinary \cite inserts commas, as usual.
+
+### Changed
+
+- Revised setup for algorithms (all contained in new file hgbalgo.sty): bug fixes, new commands, color.
+- Better handling of multiple references in citations.
+- Blocked subfigure, lstlisting, footnotes in captions.
+- Discontinued support for the subfigure package (obsolete).
+
+### Fixed
+- Fixed ToC page breaking problems using the tocbasic package (replacing the tocloft package).
+- Many small fixes and improvements.
 
 ## [2017/11/05]
 
-## Added
+### Added
 - Automatic building with `make`.
 - The bundle is distributed by CTAN as package [hagenberg-thesis](https://ctan.org/pkg/hagenberg-thesis).
 
-## Changed
+### Changed
 - Restructured setup for CTAN distribution
 - Original `.cls` and `.sty` files are now stored in `common/`.
 - Sample LaTeX documents are stored in `examples/`, with individual ZIP files for "single-click authoring" in Overleaf. Git submodules not needed any longer.
@@ -20,9 +43,9 @@ and this project DOES NOT adhere to [Semantic Versioning](http://semver.org/).
 ## [2017/10/16]
 
 ### Added
-- new classes `hgbreport` and `hgbarticle`
-- bibliography categorization
-- new bibliography examples
+- New classes `hgbreport` and `hgbarticle`.
+- Bibliography categorization.
+- New bibliography examples.
 
 ### Changed
 - PDF inclusion mechanism
@@ -30,19 +53,21 @@ and this project DOES NOT adhere to [Semantic Versioning](http://semver.org/).
 ## [2017/02/28]
 
 ### Added
-- new and unified English commands for the front matter
+- New and unified English commands for the front matter.
 
 ### Changed
-- headings in sans serif fonts
-- smaller page margins
-- two separate versions for German and English (the latter still being empty but ready to use)
+- Headings in sans serif fonts.
+- Smaller page margins.
+- Two separate versions for German and English (the latter still being empty but ready to use).
 
-## 2016/06/11
+## [2016/06/11]
 
+### Added
 This is the first release on GitHub. Future versions will now be published on this repository.
 This version has also been ported to Overleaf for online editing.
 
-[Unreleased]: https://github.com/Digital-Media/HagenbergThesis/compare/2017/11/05...master
+[Unreleased]: https://github.com/Digital-Media/HagenbergThesis/compare/2018/11/28...master
+[2018/22/28]: https://github.com/Digital-Media/HagenbergThesis/compare/2017/11/05...2018/11/28
 [2017/11/05]: https://github.com/Digital-Media/HagenbergThesis/compare/2017/10/16...2017/11/05
 [2017/10/16]: https://github.com/Digital-Media/HagenbergThesis/compare/2017/02/28...2017/10/16
 [2017/02/28]: https://github.com/Digital-Media/HagenbergThesis/compare/2016/06/11...2017/02/28

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,0 @@
-# Recent Changes
-
-* [2017/10/18] Major restructuring: Split the LaTeX source into separate GIT sub-modules (repositories) to allow smooth integration with Overleaf.
-* [2017/10/27] Revised structure to meet requirements of CTAN and Overleaf. Git submodules not needed any longer.


### PR DESCRIPTION
http://keepachangelog.com/ is an initiative to structure changelogs in an easy way. I tried to reconstruct such a changelog based on the existing GitHub tags ([releases](https://github.com/Digital-Media/HagenbergThesis/releases)). I had to remove the old `CHANGES.md` as none of the versions mentioned there were tagged on GitHub.