### PR TITLE
Disabled 'lstlisting' environment (hgblistings.sty)

### DIFF
--- a/common/hgblistings.sty
+++ b/common/hgblistings.sty
@@ -201,3 +201,19 @@ keepspaces=true,%
 	escapeinside={/+}{+/}, % makes "/+" and "+/" available for Latex escapes (labels etc.)
 	#1}}%
 {}
+
+
+% Disable the lstlisting environment (due to popular abuse)
+\newcommand{\@WarnLstlisting}{
+\GenericError{}{Package hgblistings Error: The 'lstlisting' environment is disabled}%
+{See the error note inserted in the document output for details.}{}%
+\begin{quote}
+\color{red}\textbf{NOTE:} The \texttt{lstlisting} environment has been deliberately disabled in this setup.
+Use \emph{inline code} (breakable and \emph{without} a caption) or create a \emph{float container} with 
+\texttt{{\textbackslash}begin\{program\} \ldots {\textbackslash}end\{program\}} instead!
+See the \texttt{hgbthesis} tutorial for examples.
+\end{quote}%
+}
+\renewenvironment{lstlisting}[0]%
+{\@WarnLstlisting\expandafter\comment}%
+{\expandafter\endcomment}%


### PR DESCRIPTION
The ``lstlisting`` environment (defined by the ``listings`` package) is notoriously **misused** for creating non-floating and breakable code segments in combination with captions, which is inconsistent with professional typesetting conventions. Proper alternatives are

* **inline code** that may break across pages but has **no caption**,
* a proper **float container** with caption, i.e., ``\begin{program} ... \end{program}``.

The ``lstlisting`` environment is redefined in ``hgblistings.sty``. It inserts a warning note into the document text and signals a LaTeX error to the log console. To test this behavior, try e.g.
```
\begin{lstlisting}[caption={A non-floating code segment with caption -- AVOID!}]
for i:=maxint to 0 do
begin
{ do nothing }
end;
Write('Case insensitive ');
WritE('Pascal keywords.');
\end{lstlisting}
`````