### PR TITLE
add async to js keywords

### DIFF
--- a/common/hgblistings.sty
+++ b/common/hgblistings.sty
@@ -132,7 +132,7 @@ keepspaces=true,%
 % Language Definition and Code Environment for JavaScript
 \lstdefinelanguage{JavaScript}{
     alsoletter={.},
-    keywords={arguments, await, break, case, catch, class, const, continue, debugger,%
+    keywords={arguments, async, await, break, case, catch, class, const, continue, debugger,%
 		default, delete, do, else, enum, eval, export, extends, false, finally, for,%
 		function, if, implements, import, in, instanceof, interface, let, new, null,%
 		package, private, protected, public, return, static, super, switch, this,%


### PR DESCRIPTION
Any reason this was left off? Technically, I think this is only a keyword when followed by  `function` or `(`, but then, I think `await` was only added as a keyword inside an `async` block too.