### PR TITLE
Changed "Quellkode" to "Quellcode" for easier readability.

### DIFF
--- a/dev/ctan/hagenberg-thesis/examples/HgbThesisDE/back/anhang_d.tex
+++ b/dev/ctan/hagenberg-thesis/examples/HgbThesisDE/back/anhang_d.tex
@@ -1,3 +1,3 @@
-\chapter{\latex-Quellkode}
+\chapter{\latex-Quellcode}
 \label{app:Quellcode}
 

--- a/dev/ctan/hagenberg-thesis/examples/HgbThesisTutorial/back/anhang_d.tex
+++ b/dev/ctan/hagenberg-thesis/examples/HgbThesisTutorial/back/anhang_d.tex
@@ -1,4 +1,4 @@
-\chapter{\latex-Quellkode}
+\chapter{\latex-Quellcode}
 \label{app:latex}
 
 \section*{Hauptdatei \texttt{main.tex}}
@@ -13,7 +13,7 @@ in einem Anhang sein. Die dazu verwendeten Anweisungen sind folgende:
 \end{footnotesize}
 \end{LaTeXCode}
 %
-Natürlich ist der \latex-Quellkode der eigenen
+Natürlich ist der \latex-Quellcode der eigenen
 Abschlussarbeit meist \emph{nicht} interessant genug, um ihn hier
 wiederzugeben!
 

--- a/documents/HgbThesisDE/back/anhang_d.tex
+++ b/documents/HgbThesisDE/back/anhang_d.tex
@@ -1,3 +1,3 @@
-\chapter{\latex-Quellkode}
+\chapter{\latex-Quellcode}
 \label{app:Quellcode}
 

--- a/documents/HgbThesisTutorial/back/anhang_d.tex
+++ b/documents/HgbThesisTutorial/back/anhang_d.tex
@@ -1,4 +1,4 @@
-\chapter{\latex-Quellkode}
+\chapter{\latex-Quellcode}
 \label{app:latex}
 
 \section*{Hauptdatei \texttt{main.tex}}
@@ -13,7 +13,7 @@ in einem Anhang sein. Die dazu verwendeten Anweisungen sind folgende:
 \end{footnotesize}
 \end{LaTeXCode}
 %
-Natürlich ist der \latex-Quellkode der eigenen
+Natürlich ist der \latex-Quellcode der eigenen
 Abschlussarbeit meist \emph{nicht} interessant genug, um ihn hier
 wiederzugeben!
 


### PR DESCRIPTION
The word could be written with 'k', but "Quellcode" is more common and easier to read.