### PR TITLE
Rephrase documents to gender-sensitive language

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,13 +8,11 @@ and this project DOES NOT adhere to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
+- 2020/10/28: Added a section about gender-sensitive language and writing style.
 - 2020/10/07: Cleanup of technical issues (software setup, workflow, printing) in ``HgbThesisTutorial``.
-
 - 2020/06/26: Changed bibliography section titles from `Audio-visual media` (`Audiovisuelle Medien`) to `Media` (`Medien`) to include media types that are non-A/V (e.g., still images).
-
 - 2020/06/21: Added hints in `HgbThesisTutorial` for citing musical scores. Modified `Appendix B` (listing of supplementary materials),
 replacing obsolete CD/DVD by cloud archive submission.
-
 - 2020/03/04: Modified repository setup (without GIT submodules) and adapted build process.
 All build-related parts are now contained in the new ``dev/`` directory, where
 .sty, .cls and .bib files are stored in a single place (``dev/latex/``).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ dummy markers are not required any more. Experimental: ``latexmk`` is used in th
 ### Changed
 
 - 2020/01/31: Top-level folder ``examples`` renamed to ``documents``.
+- 2020/10/27: Used gender-sensitive language in all German template documents. Also switched the example names to gender-neutral versions. Also updated references to their latest versions.
 
 ### Fixed
 

--- a/documents/HgbArticle/main.tex
+++ b/documents/HgbArticle/main.tex
@@ -21,10 +21,10 @@
 
 
 \author{
-Peter A.\ Wiseguy\\ 
+Alex A.\ Wiseguy\\ 
 \texttt{wiseguy@gmail.com}
 \and
-George Spongehead\\
+Adrian Spongehead\\
 \texttt{spongehead@gmx.net}}
 
 \title{Reasoning About the Unreasonable}

--- a/documents/HgbInternshipReport/main.tex
+++ b/documents/HgbInternshipReport/main.tex
@@ -20,13 +20,13 @@
 %%%----------------------------------------------------------
 
 \title{Endbericht zum Berufspraktikum bei Mogulovich International}
-\author{Peter A.\ Schlaumeier}
+\author{Alex A.\ Schlaumeier}
 
 \programtype{Fachhochschul-Bachelorstudiengang}
 \programname{Medientechnik und -design}
 \placeofstudy{Hagenberg}
 
-\dateofsubmission{2019}{07}{20}
+\dateofsubmission{2021}{07}{20}
 \advisor{Pjotr I.~Czar, M.A.}
 \companyName{%
    Mogulovich International Media GmbH\\
@@ -53,14 +53,14 @@ genauer beschrieben werden. Neben der eigentlichen Arbeit sollten aber auch folg
 %
 \begin{itemize}
 \item Abläufe (Workflows) innerhalb des Unternehmens bzw.\ in Projekten (grafische Darstellungen
-können dabei nützlich sein)
-\item Arbeits- und Führungsstil, Kommunikation innerhalb des Unternehmens
-\item Kommunikation nach außen (Kunden, Partner)
-\item Zeitsituation, Terminprobleme
-\item Einbettung in das Team, soziale Erfahrungen
-\item Einsatz von speziellen Techniken, Methoden und Werkzeugen.
-\item Wichtige Herausforderungen oder Schwierigkeiten
-\item Anforderungen in Bezug auf die Ausbildung im Studium (gut einsetzbare Kenntnisse, Defizite)
+können dabei nützlich sein),
+\item Arbeits- und Führungsstil, Kommunikation innerhalb des Unternehmens,
+\item Kommunikation nach außen (Kunden, Partner),
+\item Zeitsituation, Terminprobleme,
+\item Einbettung in das Team, soziale Erfahrungen,
+\item Einsatz von speziellen Techniken, Methoden und Werkzeugen,
+\item wichtige Herausforderungen oder Schwierigkeiten,
+\item Anforderungen in Bezug auf die Ausbildung im Studium (gut einsetzbare Kenntnisse, Defizite).
 \end{itemize}
 %
 Die nachfolgenden Kapitelüberschriften sollen nur zur Orientierung für die Struktur des Berichts dienen, über die konkrete Einteilung und den Wortlaut kann man natürlich selbst entscheiden.

--- a/documents/HgbLabReportDE/main.tex
+++ b/documents/HgbLabReportDE/main.tex
@@ -24,8 +24,8 @@
 \setcounter{chapter}{3}	% <----- Auf die Übungsnummer setzen
 %%-----------------------------------------------------------
 
-\author{Peter A.\ Schlaumeier}
-\title{MTD128 Digitale Medientechnik II -- SS 2017\\
+\author{Alex A.\ Schlaumeier}
+\title{MTD128 Digitale Medientechnik II -- SS 2021\\
 				Übungsabgabe \arabic{chapter}}
 \date{\today}
 

--- a/documents/HgbLabReportEN/main.tex
+++ b/documents/HgbLabReportEN/main.tex
@@ -24,8 +24,8 @@
 \setcounter{chapter}{3}	% <----- set to assignment number!
 %%-----------------------------------------------------------
 
-\author{Peter A.\ Wiseguy}
-\title{MTD362 Digital Imaging -- WS 2016/17\\
+\author{Alex A.\ Wiseguy}
+\title{MTD362 Digital Imaging -- WS 2020/21\\
 				Lab Report \arabic{chapter}}
 \date{\today}
 

--- a/documents/HgbTermReport/main.tex
+++ b/documents/HgbTermReport/main.tex
@@ -57,7 +57,7 @@ include them using \verb!\include{..}!.
 
 \bigskip
 \noindent
-Use the abstract to provide a short summary of the contents of the document.
+Use the abstract to provide a short summary of the document's contents.
 \end{abstract}
 
 

--- a/documents/HgbTermReport/main.tex
+++ b/documents/HgbTermReport/main.tex
@@ -16,7 +16,7 @@
 \bibliography{references}  % requires file 'references.bib'
 
 %%%----------------------------------------------------------
-\author{Peter A.\ Wiseguy}										% your name
+\author{Alex A.\ Wiseguy}										% your name
 \title{CS799 Ridiculously Advanced Systems\\	% the name of the course or project
 			Term Report}	% or "Project Report"
 \date{\today}
@@ -57,7 +57,7 @@ include them using \verb!\include{..}!.
 
 \bigskip
 \noindent
-Use the abstract to provide a short summary of the contents in the document.
+Use the abstract to provide a short summary of the contents of the document.
 \end{abstract}
 
 
@@ -90,7 +90,7 @@ learned \etc
 %%%----------------------------------------------------------
 
 Give a well-structured description of the architecture and the technical design
-o your implementation,
+of your implementation,
 with sufficient granularity to enable an external person to
 continue working on the project.
 
@@ -110,7 +110,7 @@ Point out issues that may warrant further investigation.
 \chapter{Supplementary Materials}
 %%%----------------------------------------------------------
 
-The appendix is a good place to attach a user guide, screenshots, installation instructions etc.
+The appendix is a good place to attach a user guide, screenshots, installation instructions, etc.
 Add a separate chapter for each major item.
 
 

--- a/documents/HgbTermReport/main.tex
+++ b/documents/HgbTermReport/main.tex
@@ -90,7 +90,7 @@ learned \etc
 %%%----------------------------------------------------------
 
 Give a well-structured description of the architecture and the technical design
-of your implementation,
+of your implementation
 with sufficient granularity to enable an external person to
 continue working on the project.
 

--- a/documents/HgbThesisDE/main.tex
+++ b/documents/HgbThesisDE/main.tex
@@ -26,14 +26,14 @@
 
 %%% Einträge für ALLE Arbeiten: -----------------------------
 \title{Partielle Lösungen zur allgemeinen Problematik}
-\author{Peter A.\ Schlaumeier}
+\author{Alex A.\ Schlaumeier}
 
 %\programtype{Fachhochschul-Bachelorstudiengang}		% select/edit
 \programtype{Fachhochschul-Masterstudiengang}
 
 \programname{Universal Computing}
 \placeofstudy{Hagenberg}
-\dateofsubmission{2019}{07}{28}	% {YYYY}{MM}{DD}
+\dateofsubmission{2021}{07}{15}	% {YYYY}{MM}{DD}
 
 \advisor{Alois B.~Treuer, Päd.\ Phil.}	% optional
 

--- a/documents/HgbThesisEN/main.tex
+++ b/documents/HgbThesisEN/main.tex
@@ -26,14 +26,14 @@
 
 %%% Entries for ALL types of work: --------------------------
 \title{Partial Solutions to Universal Problems}
-\author{Peter A.\ Wiseguy}
+\author{Alex A.\ Wiseguy}
 
 %\programtype{Fachhochschul-Bachelorstudiengang}		% select/edit
 \programtype{Fachhochschul-Masterstudiengang}
 
 \programname{Universal Computing}
 \placeofstudy{Hagenberg}
-\dateofsubmission{2019}{07}{28}	% {YYYY}{MM}{DD}
+\dateofsubmission{2021}{07}{15}	% {YYYY}{MM}{DD}
 
 \advisor{Roger K.~Putnik, M.Sc.}	% optional
 

--- a/documents/HgbThesisTutorial/back/anhang_a.tex
+++ b/documents/HgbThesisTutorial/back/anhang_a.tex
@@ -90,8 +90,7 @@ Für Mac~OS empfiehlt sich die folgende Konfiguration:
 		Um die Pakete der \LaTeX-Distribution aktuell zu halten, sollte regelmäßig das \texttt{TeX Live Utility}
 		ausgeführt werden.}
 	(\latex-Basisumgebung),
-\item \textbf{TeXstudio}%
-	(Editor, unterstützt UTF-8 und beinhaltet einen integrierten PDF-Viewer).
+\item \textbf{TeXstudio} (Editor, unterstützt UTF-8 und beinhaltet einen integrierten PDF-Viewer).
 \end{enumerate}
 %
 Alternative Editoren und PDF-Viewer:
@@ -115,8 +114,7 @@ Unter Linux kann folgendes Setup zum Einsatz kommen:
 	\footnote{\url{https://tug.org/texlive/} -- Eine Installation unter Linux erfolgt -- abhängig von der verwendeten
 	Distribution -- am einfachsten mit Hilfe des jeweiligen Paketverwaltungssystems (\zB \texttt{apt-get}).}
 	(\latex-Basisumgebung),
-	\item \textbf{TeXstudio}%
-	(Editor, unterstützt UTF-8 und beinhaltet einen integrierten PDF-Viewer).
+	\item \textbf{TeXstudio} (Editor, unterstützt UTF-8 und beinhaltet einen integrierten PDF-Viewer).
 \end{enumerate}
 %
 Alternative Editoren und PDF-Viewer:
@@ -137,7 +135,7 @@ erstellt oder auch bestehende Vorlagen (wie etwa dieses Dokument) hochgeladen un
 ermöglichen darüber hinaus ein kollaboratives Arbeiten an einem Dokument.
 
 Der bekannteste und mit dieser Vorlage getestete Editor ist \textbf{Overleaf}\footnote{\url{https://www.overleaf.com/}}. Um schnell
-Vorlagendokumente aus dem \texttt{hagenberg-thesis} Paket zu importieren, können die Import-Links im \emph{Readme}-Abschnitt zum Github-Repository
+Vorlagendokumente aus dem \texttt{hagenberg-thesis} Paket zu importieren, können die Im\-port-Links im \emph{Readme}-Abschnitt zum Github-Repository
 dieser Vorlage\footnote{\url{https://github.com/Digital-Media/HagenbergThesis}} direkt verwendet werden.
 
 Alternativ existieren noch weitere Online-Editoren:

--- a/documents/HgbThesisTutorial/back/anhang_b.tex
+++ b/documents/HgbThesisTutorial/back/anhang_b.tex
@@ -23,7 +23,7 @@ Hochschule eingereicht wurden (als ZIP-Datei).
 
 \section{Online-Quellen (PDF-Kopien)}
 \begin{FileList}{/online-sources}
-\fitem{Reliquienschrein-Wikipedia.pdf} \citenobr{WikiReliquienschrein2018}
+\fitem{Reliquienschrein-Wikipedia.pdf} \citenobr{WikiReliquienschrein2020}
 \end{FileList}
 
 

--- a/documents/HgbThesisTutorial/back/anhang_c.tex
+++ b/documents/HgbThesisTutorial/back/anhang_c.tex
@@ -6,7 +6,7 @@ Dieser Abschnitt demonstriert -- als Beispiel -- die Einbindung eines externen P
 in das eigene \latex-Manuskript.
 Dieses Problem stellt sich relativ häufig im Zusammenhang mit Fragebögen, die
 man für seine Arbeit erstellt und/oder verwendet hat, daher ist genau dieser Fall hier gezeigt.%
-\footnote{Mit einem schönen Fragebogen des OÖ Energiesparverbands (\url{http://www.energiesparverband.at}).}
+\footnote{Mit einem schönen Fragebogen des OÖ Energiesparverbands (\url{https://www.energiesparverband.at/}).}
 Wichtig ist dabei, dass die \emph{Seitenformatierung} des Dokuments intakt bleibt 
 und die fortlaufende \emph{Seitennummerierung} die eingefügten Fremdseiten korrekt berücksichtigt.
 

--- a/documents/HgbThesisTutorial/chapters/abbildungen.tex
+++ b/documents/HgbThesisTutorial/chapters/abbildungen.tex
@@ -35,7 +35,7 @@ nicht zu weit von der ursprünglichen Textstelle zu entfernen.
 
 Der Gedanke, dass etwa Abbildungen kaum jemals genau an der
 ge\-wünsch\-ten Stelle und möglicherweise nicht einmal auf
-derselben Seite Platz finden, ist für viele Anfänger aber offenbar sehr
+derselben Seite Platz finden, ist für viele Anfänger*innen aber offenbar sehr
 ungewohnt oder sogar beängstigend. Dennoch sollte zunächst einmal
 getrost \latex\ diese Arbeit überlassen und \emph{nicht} manuell
 eingegriffen werden. Erst am Ende, wenn das gesamte Dokument "steht" und
@@ -138,7 +138,7 @@ aufweisen. Im Gegensatz dazu sollte JPEG nur dann verwendet werden, wenn das Ori
 Die Bilder werden üblicherweise in einem Unterverzeichnis (oder in mehreren Unterverzeichnissen) abgelegt,
 im Fall dieses Dokuments in \nolinkurl{images/}.
 Dazu dient die folgende Anweisung
-am Beginn des Hauptdokuments \nolinkurl{_DaBa.tex} (\sa\ Anhang \ref{app:latex}):
+am Beginn des Hauptdokuments \nolinkurl{main.tex} (\sa\ Anhang \ref{app:latex}):
 %
 \begin{quote}
 \verb!\graphicspath{{images/}}!
@@ -186,8 +186,8 @@ richtig einzustellen.
 Brauchbare Auflösungen bezogen auf die endgültige Bildgröße sind:
 %
 \begin{itemize}
-  \item \textbf{Farb- und Grauwertbilder:} 150--300 dpi
-  \item \textbf{Binärbilder (Schwarz/Weiß):} 300--600 dpi
+  \item \textbf{Farb- und Grauwertbilder:} 150--300 dpi,
+  \item \textbf{Binärbilder (Schwarz/Weiß):} 300--600 dpi.
 \end{itemize}
 %
 Eine wesentlich höhere Auflösung macht aufgrund der beim Laserdruck notwendigen
@@ -208,10 +208,10 @@ Eine Ausnahme ist, wenn die Originaldaten nur in JPEG vorliegen und für die
 Einbindung nicht bearbeitet oder verkleinert wurden. Ansonsten sollte immer
 PNG verwendet werden.
 
-Besonders gerne werden farbige \textbf{Screenshots} einer JPEG-Kompression%
+Besonders gerne werden farbige \textbf{Screenshots} der JPEG-Kompression%
 \footnote{Das JPEG-Verfahren ist für natürliche Fotos konzipiert und sollte auch
 nur dafür verwendet werden.}
-unter\-zogen, obwohl deren verheerende Folgen für jeden Laien sichtbar sein sollten
+unter\-zogen, obwohl deren verheerende Folgen für jede*n Laiin*Laien sichtbar sein sollten
 (Abb.~\ref{fig:jpeg-pfusch}).
 
 \begin{figure}
@@ -277,7 +277,7 @@ Die ursprüngliche Inkscape-Grafik \nolinkurl{images/inkscape-template.svg}  ent
 Texte, die nachträglich von \latex\ ersetzt werden sollen 
 (siehe Abb.~\ref{fig:InkscapeExample}\,(a)).
 \item
-Durch \textsf{Save a Copy...} (als PDF) in Inkscape, mit den Einstellungen wie in 
+Mit Hilfe von \textsf{Save a Copy...} (als PDF) in Inkscape und den Einstellungen wie in 
 Abb.~\ref{fig:InkscapeExample}\,(c), werden folgende zwei Files erzeugt:
 \begin{itemize}
 \item[] \nolinkurl{inkscape-template.pdf}: eine PDF-Datei der Grafik ohne Texte, 
@@ -328,7 +328,7 @@ beabsichtigt im Ausdruck aufscheinen.
 
 \subsubsection{Strichstärken -- \emph{Hairlines} vermeiden!}
 
-In Grafik-Programmen wie \emph{Freehand} und \emph{Illustrator},
+In Grafik-Programmen wie \emph{Inkscape} und \emph{Illustrator},
 die sich im Wesentlichen an der \emph{PostScript}-Funktionalität
 orientieren, ist es möglich, Linien bzgl.\ ihrer Stärke als
 "Hairline" zu definieren. Im zugehörigen \emph{PostScript}-Code
@@ -349,7 +349,7 @@ Strichstärken ($\geq 0.25\,\mathrm{pt}$) einstellen!
 Während bei Abbildungen, die mit externen
 Grafik-Programmen erzeugt werden, meist mit ähnlich aussehende
 Schriften (wie \emph{Times-Roman} oder \emph{Garamond}) Abhilfe schaffen,
-besteht bei Puristen oft der verständliche Wunsch, die 
+besteht bei Purist*innen oft der verständliche Wunsch, die 
 \emph{Computer-Modern} (CM) Schriftfamilie von {\tex}/{\latex} auch
 innerhalb von eingebetteten Grafiken einzusetzen.
 
@@ -372,7 +372,7 @@ Eine Alternative dazu sind die "LM-Roman"%
 \footnote{\url{http://www.gust.org.pl/projects/e-foundry/latin-modern}}
  Open-Type Schriften, die speziell für die Verwendung im Umfeld von \latex\ entwickelt wurden.
 Sie sind auch Teil der MikTeX-Installation.%
-\footnote{\zB unter \url{C:/Program Files (x86)/MikTeX 2.9/fonts/opentype/public/lm/}}
+\footnote{\zB unter \url{C:/Program Files/MiKTeX 2.9/fonts/opentype/public/lm}}
 Diese Schriften enthalten \ua\ Zeichen mit Umlauten und sind daher auch für 
 deutsche Texte recht bequem zu verwenden.
 
@@ -505,15 +505,15 @@ findet sich in Prog.~\ref{prog:processors-source}.
 \label{tab:processors}
 \centering
 \setlength{\tabcolsep}{5mm}	% separator between columns
-\def\arraystretch{1.25}			% vertical stretch factor (Standard = 1.0)
+\def\arraystretch{1.25}     % vertical stretch factor (Standard = 1.0)
 \begin{tabular}{|r||c|c|c|} \hline
 & \emph{PowerPC} & \emph{Pentium} & \emph{Athlon} \\
 \hline\hline
 Manufacturer & Motorola & Intel & AMD \\
 \hline
-Speed & high & medium & high   \\
+Speed & high & medium & high \\
 \hline
-Price & high & high   & medium \\
+Price & high & high  & medium \\
 \hline
 \end{tabular}
 \end{table}
@@ -538,9 +538,9 @@ Die Erzeugung des dargestellten Listings selbst ist in Abschn.\ \ref{sec:program
 		\hline
 		Manufacturer & Motorola & Intel & AMD \\
 		\hline
-		Speed & high & medium & high   \\
+		Speed & high & medium & high \\
 		\hline
-		Price & high & high   & medium \\
+		Price & high & high & medium \\
 		\hline
 	\end{tabular}
 \end{table}
@@ -640,7 +640,7 @@ Die Einbindung von Programmtexten (source code) ist eine häufige Notwendigkeit,
 \subsection{Formatierung von Programmcode}
 \label{sec:FormatierungVonProgrammcode}
 
-Es gibt für \latex\ spezielle Pakete zur Darstellung von Programmen, die \ua\ auch die automatische
+Es existieren für \latex\ spezielle Pakete zur Darstellung von Programmen, die \ua\ auch die automatische
 Nummerierung der Zeilen vornehmen, insbesondere die Pakete \texttt{listings}%
 \footnote{\url{https://ctan.org/pkg/listings}}
 und \texttt{listingsutf8}.%
@@ -806,7 +806,7 @@ Wenn gewünscht, kann die Caption auch unten angebracht werden
 (jedenfalls aber konsistent und nicht gemischt).
 Natürlich darf auch hier nicht mit einer linearen Abfolge im fertigen
 Druckbild gerechnet werden, daher sind Wendungen wie
-"... im  folgenden Programmstück ..." zu vermeiden und entsprechende Verweise
+"\ldots\ im  folgenden Programmstück \ldots" zu vermeiden und entsprechende Verweise
 einzusetzen. Beispiele sind Programme \ref{prog:processors-source} und \ref{prog:CodeExample}.
 
 \begin{program}
@@ -856,6 +856,6 @@ solches Beispiel ist der \latex-Quellcode in Anhang
 \ref{app:latex} (Seite \pageref{app:latex}).%
 \footnote{%
 Grundsätzlich ist zu überlegen, ob die gedruckte Einbindung der gesamten
-Programmtexte einer Implementierung für den Leser überhaupt sinnvoll ist, oder
+Programmtexte einer Implementierung für den*die Leser*in überhaupt sinnvoll ist, oder
 ob diese nicht besser elektronisch (auf Datenträger) beigefügt und nur exemplarisch
 beschrieben werden.}

--- a/documents/HgbThesisTutorial/chapters/abbildungen.tex
+++ b/documents/HgbThesisTutorial/chapters/abbildungen.tex
@@ -806,8 +806,8 @@ Wenn gewünscht, kann die Caption auch unten angebracht werden
 (jedenfalls aber konsistent und nicht gemischt).
 Natürlich darf auch hier nicht mit einer linearen Abfolge im fertigen
 Druckbild gerechnet werden, daher sind Wendungen wie
-"\ldots\ im  folgenden Programmstück \ldots" zu vermeiden und entsprechende Verweise
-einzusetzen. Beispiele sind Programme \ref{prog:processors-source} und \ref{prog:CodeExample}.
+"\ldots\ im folgenden Programmstück \ldots" zu vermeiden und entsprechende Verweise
+einzusetzen. Beispiele sind die Programme \ref{prog:processors-source} und \ref{prog:CodeExample}.
 
 \begin{program}
 % place caption consistently either at the top or bottom:

--- a/documents/HgbThesisTutorial/chapters/abbildungen.tex
+++ b/documents/HgbThesisTutorial/chapters/abbildungen.tex
@@ -115,7 +115,7 @@ Bildquelle~\cite{IBM360}.}
 \section{Abbildungen}
 
 Für die Einbindung von Grafiken in \latex wird die Verwendung des Stan\-dard-Pakets
-\texttt{graphicx} \cite{Carlisle2017} empfohlen 
+\texttt{graphicx} \cite{Carlisle2020} empfohlen 
 (wird durch das \texttt{hagenberg-thesis}-Paket bereits eingebunden). 
 Mit dem aktuell verwendeten Workflow (\texttt{pdflatex})
 können Bild- bzw.\ Grafikformate ausschließlich 

--- a/documents/HgbThesisTutorial/chapters/abschlussarbeit.tex
+++ b/documents/HgbThesisTutorial/chapters/abschlussarbeit.tex
@@ -46,6 +46,41 @@ Und natürlich ist es auch nicht verboten, seine eigene Meinung
 in sachlicher Form zu äußern.
 
 
+\section{Sprache und Schreibstil}
+
+Abschlussarbeiten sind wissenschaftliche Arbeiten und sollten daher knapp,
+nüchtern und sachlich formuliert sein. Die eigene Person tritt dabei hinter
+den Gegenstand der Arbeit zurück, auf die "Ich-Form", oder auch Formulierungen
+wie "der*die Autor*in" sollte verzichtet werden. Abhilfe können im Deutschen
+dabei Passivwendungen schaffen, wenngleich zu beachten ist, dass dabei kein
+allzu komplizierter Satzbau entsteht.
+
+Ausdrucksweisen wie Umgangssprache, polemische Formulierungen oder auch
+Ironie und Zynismus sind fehl am Platz, ebenso eine übermäßige Verwendung von
+Fremdwörtern (etwa Anglizismen).
+
+Die Sprache in Abschlussarbeiten soll darüber hinaus geschlechtergerecht und
+diskriminierungsfrei sein und dabei alle Menschen in ihrer Vielfalt gleichwertig
+in Wort und Bild sichtbar machen. Um dies zu erreichen, bedient sich diese
+Vorlage der Verwendung des Gendersterns (*). Dieser macht im Deutschen bei
+Personenbezeichnungen zugleich Männer, Frauen und alle weiteren
+Geschlechteridentitäten sichtbar und leistet somit auch dem gesetzlich
+festgelegten Geschlechtseintrag \emph{divers} sprachlich Folge.
+
+Anstelle von "dem User", "Studenten" oder "Teilnehmern" sollte in der eigenen
+Arbeit also von "dem*der User*in", "Student*innen" oder "Teilnehmer*innen"
+gesprochen werden. Abwechselnd können dazu neutrale Formen wie "Studierende" oder
+"Teilnehmende" zum Einsatz kommen.
+
+Abschließend sei angemerkt, dass in der deutschen Rechtschreibung derzeit noch
+keine Variante der geschlechtergerechten Sprache normiert wurde, weshalb viele
+Aspekte wie die korrekte Art Silbentrennung rund um den Stern, noch nicht final
+geklärt sind. Dies sollte jedoch nicht zur Ausrede genommen werden, um auf
+geschlechtergerechte Formulierungen zu verzichten. Vielmehr sollte -- gerade in
+einer wissenschaftlichen Arbeit -- das Potential von Sprache genützt werden, um
+stereotypen Vorstellungen über die gesellschaftlichen Rollen entgegenzuwirken.
+
+
 \section{Arbeiten in Englisch}
 \label{sec:englisch}
 

--- a/documents/HgbThesisTutorial/chapters/abschlussarbeit.tex
+++ b/documents/HgbThesisTutorial/chapters/abschlussarbeit.tex
@@ -31,8 +31,8 @@ noch offen geblieben, wo könnte weiter gearbeitet werden?
 \end{enumerate}
 %
 Natürlich ist auch ein gewisser dramaturgischer Aufbau der Arbeit
-wichtig, wobei zu bedenken ist, dass der Leser in der Regel nur
-wenig Zeit hat und -- anders als etwa bei einem Roman -- seine
+wichtig, wobei zu bedenken ist, dass der*die Leser*in in der Regel nur
+wenig Zeit hat und -- anders als etwa bei einem Roman -- seine*ihre
 Geduld nicht auf die lange Folter gespannt werden darf. Erklären
 Sie bereits in der Einführung (und nicht erst im letzten Kapitel),
 wie Sie an die Sache herangehen, welche Lösungen Sie vorschlagen
@@ -91,7 +91,7 @@ Abschn.~\ref{sec:anfuehrungszeichen}), für eine englische Arbeit
 nicht viel zu ändern, allerdings sollte Folgendes beachtet werden:
 %
 \begin{itemize}
-\item  Die Titelseite (mit der Bezeichnung "Diplomarbeit" oder "Masterarbeit") 
+\item  Die Titelseite (mit der Bezeichnung "Bachelorarbeit" oder "Masterarbeit") 
 ist für die einzureichenden Exemplare jedenfalls in \emph{deutsch} zu halten,
 auch wenn der Titel englisch ist. 
 \item Ebenso muss neben dem

--- a/documents/HgbThesisTutorial/chapters/drucken.tex
+++ b/documents/HgbThesisTutorial/chapters/drucken.tex
@@ -61,27 +61,27 @@ kontrolliert werden!
 \section{Binden}
 
 Die Endfassung der Abschlussarbeit%
-\footnote{Für \textbf{Bachelorarbeiten} genügt, je nach Vorgaben des Studiengangs, meist eine einfache Bindung (Copyshop oder Bibliothek).}
-ist in fest gebundener Form
-einzureichen.%
+\footnote{Für \textbf{Bachelorarbeiten} genügt, je nach Vorgaben des Studiengangs,
+	meist eine einfache Bindung (Copyshop oder Bibliothek).}
+ist in fest gebundener Form einzureichen.%
 \footnote{An der Fakultät Hagenberg ist bei Masterarbeiten zumindest eines der
-Exemplare \emph{ungebunden} abzugeben -- dieses wird später von einem
-Buchbinder in einheitlicher Form gebunden und verbleibt
+Exemplare \emph{ungebunden} abzugeben -- dieses wird später von einem*einer
+Buchbinder*in in einheitlicher Form gebunden und verbleibt
 danach in der Bibliothek. Datenträger sind bei diesem Exemplar lose 
 und \emph{ohne} Aufkleber (jedoch beschriftet) beizulegen.}
 Dabei ist eine Bindung zu
 verwenden, die das Ausfallen von einzelnen Seiten nachhaltig
 verhindert, \zB durch eine traditionelle Rückenbindung
-(Buchbinder) oder durch handelsübliche Klammerungen aus Kunststoff
+(Buchbinder*in) oder durch handelsübliche Klammerungen aus Kunststoff
 oder Metall. Eine einfache Leimbindung ohne Verstärkung ist
 jedenfalls \emph{nicht} ausreichend.
 
-Falls man -- was sehr zu empfehlen ist -- die Arbeit bei einem
-professionellen Buchbinder durchführen lässt, sollte man auch auf
+Falls man -- was sehr zu empfehlen ist -- die Arbeit bei einem*einer
+professionellen Buchbinder*in durchführen lässt, sollte man auch auf
 die Prägung am Buchrücken achten, die kaum zusätzliche Kosten
-verursacht. Üblich ist dabei die Angabe des Familiennamens des
-Autors und des Titels der Arbeit. Ist der Titel der Arbeit zu
-lang, muss man notfalls eine gekürzte  Version angeben, wie \zB:
+verursacht. Üblich ist dabei die Angabe des Familiennamens des*der
+Autors*Autorin und des Titels der Arbeit. Ist der Titel der Arbeit zu
+lang, muss man notfalls eine gekürzte Version angeben, wie \zB:
 %
 \begin{center}
 \setlength{\fboxsep}{3mm}

--- a/documents/HgbThesisTutorial/chapters/einleitung.tex
+++ b/documents/HgbThesisTutorial/chapters/einleitung.tex
@@ -16,7 +16,7 @@ nachfolgenden Jahren, die zu einigen zusätzlichen Hinweisen Anlass gaben.
 Das vorliegende Dokument dient einem zweifachen Zweck: 
 \emph{erstens} als Erläuterung und Anleitung, \emph{zweitens} als
 direkter Ausgangspunkt für die eigene Arbeit. Angenommen wird,
-dass der Leser bereits über elementare Kenntnisse im Umgang mit
+dass der*die Leser*in bereits über elementare Kenntnisse im Umgang mit
 \latex verfügt. In diesem Fall sollte -- eine einwandfreie
 Installation der Software vorausgesetzt -- der Arbeit nichts mehr
 im Wege stehen. Auch sonst ist der Start mit \latex\ nicht
@@ -53,20 +53,20 @@ Microsoft \emph{Word} gilt im Unterschied zu \latex,
 \emph{Framemaker} und \emph{InDesign} übrigens nicht als professionelle
 Textverarbeitungssoftware, obwohl es immer häufiger auch von
 großen Verlagen verwendet wird.%
-\footnote{Siehe auch \url{http://latex.tugraz.at/mythen.php}.}
+\footnote{Siehe auch \url{https://latex.tugraz.at/dokumentation/mythen}.}
 Das Schriftbild in \emph{Word}
 lässt -- zumindest für das geschulte Auge -- einiges zu wünschen
 übrig und das Erstellen von Büchern und ähnlich großen Dokumenten
 wird nur unzureichend unterstützt. Allerdings ist \emph{Word} sehr
-verbreitet, flexibel und vielen Benutzern zumindest oberflächlich
+verbreitet, flexibel und vielen Benutzer*innen zumindest oberflächlich
 vertraut, sodass das Erlernen eines speziellen Werkzeugs wie
 \latex\ ausschließlich für das Erstellen einer Abschlussarbeit
 manchen verständlicherweise zu mühevoll ist. Es sollte daher
-niemandem übel genommen werden, wenn er/sie sich auch bei der Abschlussarbeit
+niemandem übel genommen werden, wenn er*sie sich auch bei der Abschlussarbeit
 auf \emph{Word} verlässt. Im Endeffekt lässt sich mit etwas
 Sorgfalt (und ein paar Tricks) auch damit ein durchaus akzeptables
 Ergebnis erzielen. 
-Ansonsten sollten auch für \emph{Word}-Benutzer 
+Ansonsten sollten auch für \emph{Word}-Benutzer*innen 
 einige Teile dieses Dokuments von Interesse sein, insbesondere die
 Abschnitte über Abbildungen und Tabellen
 (Kap.~\ref{cha:Abbildungen}) und mathematische Elemente

--- a/documents/HgbThesisTutorial/chapters/latex.tex
+++ b/documents/HgbThesisTutorial/chapters/latex.tex
@@ -451,7 +451,7 @@ ausschließlich "ungebrochene" Nummern:
 \section{Wortabstand und Interpunktion}
 
 Während \latex in vielen Bereichen des Schriftsatzes automatisch das
-bestmögliche Ergebnis zu erzielen versucht, ist im Bereich der Interpunktion
+bestmögliche Ergebnis zu erzielen versucht, ist bei der Interpunktion
 Sorgfalt von Seiten des*der Autors*Autorin gefragt.
 
 \subsection{\emph{French Spacing}}

--- a/documents/HgbThesisTutorial/chapters/latex.tex
+++ b/documents/HgbThesisTutorial/chapters/latex.tex
@@ -99,14 +99,14 @@ Comprehensive TeX Archive Network} (CTAN) auf
 \end{quote}
 %
 Besonders nützlich sind auch die
-\emph{Comprehensive List of \textrm{\latex} Symbols} \cite{Pakin2017}
+\emph{Comprehensive List of \textrm{\latex} Symbols} \cite{Pakin2020}
 und die Beschreibungen wichtiger \latex-Pakete, wie
 %
 \begin{quote}
-  \texttt{babel} \cite{Bezos2018},\newline
-  \texttt{graphics}, \texttt{graphicx} \cite{Carlisle2017},\newline
+  \texttt{babel} \cite{Bezos2020},\newline
+  \texttt{graphics}, \texttt{graphicx} \cite{Carlisle2020},\newline
   \texttt{fancyhdr} \cite{Oostrum2019},\newline
-  \texttt{caption} \cite{Sommerfeldt2011}.
+  \texttt{caption} \cite{Sommerfeldt2020}.
 \end{quote}
 
 

--- a/documents/HgbThesisTutorial/chapters/latex.tex
+++ b/documents/HgbThesisTutorial/chapters/latex.tex
@@ -7,7 +7,7 @@
 \latex ist eine in den Naturwissenschaften sehr verbreitete
 und mittlerweile klassische Textverarbeitungssoftware für das Erstellen
 großer und komplizierter Dokumente mit professionellem Anspruch.
-Das Arbeiten mit \latex erscheint -- zumindest für den ungeübten Benutzer -- %
+Das Arbeiten mit \latex erscheint -- zumindest für ungeübte Benutzer*innen -- %
 zunächst schwieriger als mit herkömmlichen Werkzeugen für die
 Textverarbeitung.
 
@@ -19,7 +19,7 @@ Text\-ver\-arbei\-tungs\-prog\-ram\-men -- \latex nicht \textsc{Wysiwyg}%
 \emph{LyX} (\url{https://www.lyx.org/}), 
 die aber teuer \bzw\ relativ langsam sind.},
 sondern es handelt sich um eine \emph{Markup Lang\-uage} (wie HTML) -- noch dazu
-eine für den Anfänger recht komplizierte -- und zugehörige Werkzeuge.
+eine für Anfänger*innen recht komplizierte -- und zugehörige Werkzeuge.
 Ungewohnt erscheinen sicher auch die vermeintlich starken
 Einschränkungen von \latex,
 insbesondere in Bezug auf die Wahl der Schriften und das
@@ -47,25 +47,32 @@ Das Makro \texttt{{\bs}optbreaknh} ("optional break with no hyphen") ist in
 \subsection{Software}
 \label{sec:Software}
 
-Zum Arbeiten mit \latex wird -- neben einem Computer -- natürlich Software benötigt. Mussten früher oft die einzelnen Komponenten von \latex mühevoll zusammengesucht und für die eigene Umgebung konfiguriert werden, gibt es mittlerweile für die wichtigsten Plattformen (Windows, Mac~Os, Linux) fertige \latex-Installationen, die ohne weiteres Zutun laufen. Die aktuelle Version von \latex\ ist \LaTeXe\ (sprich "LaTeX zwei e"). 
-Zum lokalen Arbeiten mit \latex\ werden zwei Dinge benötigt:
+Zum Arbeiten mit \latex wird -- neben einem Computer -- natürlich Software
+benötigt. Mussten früher oft die einzelnen Komponenten von \latex mühevoll
+zusammengesucht und für die eigene Umgebung konfiguriert werden, gibt es
+mittlerweile für die wichtigsten Plattformen (Windows, Mac~Os, Linux) fertige
+\latex-Installationen, die ohne weiteres Zutun laufen. Die aktuelle Version von
+\latex\ ist \LaTeXe\ (sprich "LaTeX zwei e"). Zum lokalen Arbeiten mit \latex\
+werden zwei Dinge benötigt:
 %
 \begin{itemize}
 \item \latex-Installation (Distribution),
-\item Texteditor oder Autorenumgebung (Frontend).
+\item Texteditor oder Autor*innenumgebung (Frontend).
 \end{itemize}
 %
 Sämtliche Komponenten sind kostenlos und für alle gängigen Plattformen verfügbar.
 
-Alternativ kann auch ein Online-Editor verwendet werden, der ein Arbeiten im Browser ermöglicht und keinerlei Installation auf dem eigenen Rechner voraussetzt.
-Details zu empfohlenen Setups und möglichen Alternativen finden sich in Anhang~\ref{app:TechnischeInfos}.
+Alternativ kann auch ein Online-Editor verwendet werden, der ein Arbeiten im
+Browser ermöglicht und keinerlei Installation auf dem eigenen Rechner
+voraussetzt. Details zu empfohlenen Setups und möglichen Alternativen finden
+sich in Anhang~\ref{app:TechnischeInfos}.
 
 
 \subsection{Literatur}
 \label{sec:literatur}
 
 Es ist müßig, ohne geeignete Literatur mit \latex zu beginnen, selbst
-fortgeschrittene Benutzer werden immer wieder auf Hilfe angewiesen
+fortgeschrittene Benutzer*innen werden immer wieder auf Hilfe angewiesen
 sein. Erfreulicherweise ist sehr viel Nützliches auch online verfügbar.
 Gute Startpunkte sind \zB
 %
@@ -112,7 +119,7 @@ In einem \latex-Dokument muss zunächst die verwendete Schriftart festgelegt wer
 \latex verwendet normalerweise die Schriften der \emph{Computer
 Modern}
 (CM) Serie, die so wie die \emph{TeX}-Software selbst von Donald Knuth%
-\footnote{\url{http://www-cs-faculty.stanford.edu/~uno/}} entwickelt
+\footnote{\url{https://www-cs-faculty.stanford.edu/~knuth/}} entwickelt
 wurden. Die drei Basis-Schrifttypen der CM-Serie in \latex sind
 %
 \begin{quote}
@@ -123,7 +130,7 @@ wurden. Die drei Basis-Schrifttypen der CM-Serie in \latex sind
 \end{tabular}
 \end{quote}
 %
-\noindent In den Augen vieler Benutzer ist allein die Qualität und
+\noindent In den Augen vieler Benutzer*innen ist allein die Qualität und
 Zeitlosigkeit dieser Schriften ein Grund, \latex für seriöse
 Zwecke zu verwenden. Ein weiterer Vorteil der \emph{TeX}-Schriften
 ist, dass die unterschiedlichen Schriftfamilien und Schnitte
@@ -373,12 +380,15 @@ Ziemlich kompliziert also, und damit
 ein weiterer Grund, Fußnoten an solchen Stellen überhaupt zu vermeiden.
 
 Generell sollte mit Fußnoten sparsam umgegangen werden, da sie den
-Textfluss unterbrechen und den Leser ablenken. Insbesondere
+Textfluss unterbrechen und den*die Leser*in ablenken. Insbesondere
 sollten Fußnoten nicht (wie \va\ in manchen
 sozialwissenschaftlichen Werken gepflegt) derart lang werden, dass
 sie einen Großteil der Seite einnehmen und damit praktisch ein
 zweites Dokument bilden.%
-\footnote{Das führt bei Dokumenten mit vielen Fußnoten bei manchen Lesern angeblich so weit, dass sie aus Neugier (oder Versehen) regelmäßig bei den Fußnoten zu lesen beginnen und dann mühevoll die zugehörigen, kleingedruckten Verweise im Haupttext suchen.}
+\footnote{Das führt bei Dokumenten mit vielen Fußnoten bei manchen
+	Leser*innen angeblich so weit, dass sie aus Neugier (oder Versehen)
+	regelmäßig bei den Fußnoten zu lesen beginnen und dann mühevoll die
+	zugehörigen, kleingedruckten Verweise im Haupttext suchen.}
 
 
 \subsection{Querverweise}
@@ -401,11 +411,11 @@ Prefix zu versehen, \zB\
 \begin{quote}
 \tabcolsep0pt
 \begin{tabular}{ll}
-\verb!cha:!\texttt{\em kapitel}   & \ \ldots\ für Kapitel  \\
-\verb!sec:!\texttt{\em abschnitt} & \ \ldots\ für Abschnitte (Sections) und Unterabschnitte \\
-\verb!fig:!\texttt{\em abbildung} & \ \ldots\ für Abbildungen \\
-\verb!tab:!\texttt{\em tabelle}   & \ \ldots\ für Tabellen \\
-\verb!equ:!\texttt{\em gleichung} & \ \ldots\ für Formeln und Gleichungen\\
+\verb!cha:!\texttt{\em kapitel}   & \ \ldots\ für Kapitel,  \\
+\verb!sec:!\texttt{\em abschnitt} & \ \ldots\ für Abschnitte (Sections) und Unterabschnitte, \\
+\verb!fig:!\texttt{\em abbildung} & \ \ldots\ für Abbildungen, \\
+\verb!tab:!\texttt{\em tabelle}   & \ \ldots\ für Tabellen, \\
+\verb!equ:!\texttt{\em gleichung} & \ \ldots\ für Formeln und Gleichungen.\\
 \end{tabular}
 \end{quote}
 %
@@ -440,7 +450,9 @@ ausschließlich "ungebrochene" Nummern:
 
 \section{Wortabstand und Interpunktion}
 
-Während \latex in vielen Bereichen des Schriftsatzes automatisch das bestmögliche Ergebnis zu erzielen versucht, ist im Bereich der Interpunktion Sorgfalt von Seiten des Autors gefragt.
+Während \latex in vielen Bereichen des Schriftsatzes automatisch das
+bestmögliche Ergebnis zu erzielen versucht, ist im Bereich der Interpunktion
+Sorgfalt von Seiten des*der Autors*Autorin gefragt.
 
 \subsection{\emph{French Spacing}}
 
@@ -636,7 +648,7 @@ Eingabe von zitierten Texten (Zitaten), insbesondere das Makro
 \item[] \verb!\enquote{text}!,
 \end{itemize}
 %
-das den angegebenen \texttt{text} in der jeweils korrekten Form (\ua\ abhängig von der Spracheinstellung und
+das den angegebenen \texttt{text} in der jeweils korrekten Form (\ua\ abhängig von der Sprach\-einstellung und
 Verschachtelungstiefe) als Zitat auszeichnet, zum Beispiel,
 %
 \begin{itemize}
@@ -743,9 +755,9 @@ Dieser Absatz wird "schlampig" (sloppy) gesetzt ...
 \end{LaTeXCode}
 %
 Der allerletzte Rettungsanker ist, die betreffende Passage so umzuschreiben, dass sich ein 
-passabler Zeilenumbruch ergibt -- schließlich ist man ja selbst der Autor und 
-niemandem (abgesehen vom Betreuer) eine Rechtfertigung schuldig.%
-\footnote{Angeblich waren eigenständige Textänderungen durch Schriftsetzer
+passabler Zeilenumbruch ergibt -- schließlich ist man ja selbst der*die Autor*in und 
+niemandem (abgesehen von dem*der Betreuer*in) eine Rechtfertigung schuldig.%
+\footnote{Angeblich waren eigenständige Textänderungen durch Schriftsetzer*innen
 auch beim früheren Bleisatz durchaus üblich.}
 
 
@@ -819,13 +831,13 @@ erforderlich:
 %
 \begin{itemize}
 \item[] %
-\verb!\title{!\texttt{\em Titel der Arbeit}\verb!}! \newline%
-\verb!\author{!\texttt{\em Autor}\verb!}! \newline%
-\verb!\programtype{!\texttt{\em Typ des Studiums}\verb!}! \newline%
-\verb!\programname{!\texttt{\em Studiengang}\verb!}! \newline%
-\verb!\placeofstudy{!\texttt{\em Studienort}\verb!}! \newline%
-\verb!\dateofsubmission{!\texttt{\em yyyy}\verb!}{!\texttt{\em mm}\verb!}{!\texttt{\em dd}\verb!}! \newline%
-\verb!\advisor{!\texttt{\em Name des Betreuers/der Betreuerin}\verb!}! -- optional
+\verb!\title{!\texttt{\em Titel der Arbeit}\verb!}!, \newline%
+\verb!\author{!\texttt{\em Autor*in}\verb!}!, \newline%
+\verb!\programtype{!\texttt{\em Typ des Studiums}\verb!}!, \newline%
+\verb!\programname{!\texttt{\em Studiengang}\verb!}!, \newline%
+\verb!\placeofstudy{!\texttt{\em Studienort}\verb!}!, \newline%
+\verb!\dateofsubmission{!\texttt{\em yyyy}\verb!}{!\texttt{\em mm}\verb!}{!\texttt{\em dd}\verb!}!, \newline%
+\verb!\advisor{!\texttt{\em Name des*der Betreuers*Betreuerin}\verb!}! -- optional.
 \end{itemize}
 %
 %\noindent Für \textbf{Bachelorarbeiten} werden \emph{zusätzlich }zu den Basisangaben folgende Elemente verwendet (bei Diplom- und Masterarbeiten nicht relevant):
@@ -897,7 +909,7 @@ automatisch generiert, abhängig von den obigen Einstellungen:
 \emph{Seite} & \emph{Inhalt} \\
   \hline
   \textrm{i} & Titelseite  \\
-  \textrm{ii} & Betreuerseite (nur wenn \verb!\advisor! angegeben) \\
+  \textrm{ii} & Betreuer*innenseite (nur wenn \verb!\advisor! angegeben) \\
 	\textrm{iii} & Copyright-Seite \\
   \textrm{iv} & Eidesstattliche Erklärung \\
   \hline

--- a/documents/HgbThesisTutorial/chapters/literatur.tex
+++ b/documents/HgbThesisTutorial/chapters/literatur.tex
@@ -25,7 +25,7 @@ Technisch basiert dieser Teil auf \texttt{BibTeX} \cite{Patashnik1988}
 \bzw\ \texttt{Biber}%
 \footnote{Wird seit Version 2013/02/19 anstelle von \texttt{bibtex} verwendet 
 	(s.\ \url{http://biblatex-biber.sourceforge.net/}).}
-in Kombination mit dem Paket \texttt{biblatex} \cite{Lehman2018}.
+in Kombination mit dem Paket \texttt{biblatex} \cite{Kime2020}.
 
 
 Die Verwaltung von Quellen besteht grundsätzlich aus zwei Elementen: 
@@ -666,17 +666,17 @@ Dieser Publikationstyp bietet sich jegliche Art von technischer oder anderer Dok
 \begin{itemize}
 \item[]
 \begin{GenericCode}[numbers=none]
-@manual{Mittelbach2018,
+@manual{Mittelbach2020,
   author={Mittelbach, Frank and Schöpf, Rainer and Downes, Michael and Jones, David M. and Carlisle, David},
   title={The \texttt{amsmath} package},
-  year={2018},
-  month={12},
-  version={2.17b},
+  year={2020},
+  month={9},
+  version={2.17i},
   url={http://mirrors.ctan.org/macros/latex/required/amsmath/amsmath.pdf},
   hyphenation={english}
 }
 \end{GenericCode}
-\item[\cite{Mittelbach2018}] \fullcite{Mittelbach2018}
+\item[\cite{Mittelbach2020}] \fullcite{Mittelbach2020}
 \end{itemize}
 %
 Oft wird bei derartigen Dokumenten kein*e Autor*in genannt. Dann wird der Name des \emph{Unternehmens} oder der \emph{Institution} im \texttt{author}-Feld angegeben, allerdings innerhalb einer \textbf{zusätzlichen Klammer} \texttt{\{..\}}, damit das Argument nicht fälschlicherweise als \emph{Vornamen} + \emph{Nachname} interpretiert wird.%
@@ -748,7 +748,7 @@ wie im nächsten Abschnitt gezeigt \cite{Hough1962}.
 
 Sollte mit den bisher angeführten Eintragungstypen für gedruckte Publikationen
 nicht das Auslangen gefunden werden, sollte man sich zunächst die weiteren (hier nicht näher beschriebenen) 
-Typen im \texttt{biblatex}-Handbuch \cite{Lehman2018} ansehen, beispielsweise
+Typen im \texttt{biblatex}-Handbuch \cite{Kime2020} ansehen, beispielsweise
 \texttt{@collection} für einen Sammelband als Ganzes (also nicht nur ein Beitrag darin).
 
 Wenn nichts davon passt, dann kann auf den Typ \texttt{@misc} zurückgegriffen werden, der ein

--- a/documents/HgbThesisTutorial/chapters/literatur.tex
+++ b/documents/HgbThesisTutorial/chapters/literatur.tex
@@ -24,7 +24,7 @@ Disziplinen üblich ist.%
 Technisch basiert dieser Teil auf \texttt{BibTeX} \cite{Patashnik1988}
 \bzw\ \texttt{Biber}%
 \footnote{Wird seit Version 2013/02/19 anstelle von \texttt{bibtex} verwendet 
-	(s.\ \url{http://biblatex-biber.sourceforge.net/}),}
+	(s.\ \url{http://biblatex-biber.sourceforge.net/}).}
 in Kombination mit dem Paket \texttt{biblatex} \cite{Lehman2018}.
 
 
@@ -114,11 +114,11 @@ angeben kann, zum Beispiel:
 \begin{itemize}
 \item
 Ähnliches findet sich auch in 
-\mcite[Kap.~2]{Artner2007}[Abschn.~3.6]{Drake1948}[S.~5--7]{Eberl1987}.
+\mcite[Kap.~2]{Loimayr2019}[Abschn.~3.6]{Drake1948}[S.~5--7]{Eberl1987}.
 %
 \begin{LaTeXCode}[numbers=none]
 Ähnliches findet sich auch in
-\mcite[Kap.~2]{Artner2007}[Abschn.~3.6]{Drake1948}[S.~5--7]{Eberl1987}.
+\mcite[Kap.~2]{Loimayr2019}[Abschn.~3.6]{Drake1948}[S.~5--7]{Eberl1987}.
 \end{LaTeXCode}
 \end{itemize}
 %
@@ -278,7 +278,7 @@ Institutionen und Verlagen) \textbf{häufig falsch oder syntaktisch fehlerhaft}!
 Man sollte sie daher nicht ungeprüft übernehmen und insbesondere die Endergebnisse genau kontrollieren.
 Darüber hinaus gibt es eigene Anwendungen zur Wartung von
 BibTeX-Verzeichnissen, wie beispielsweise
-\emph{JabRef}.\footnote{\url{http://www.jabref.org/}}
+\emph{JabRef}.\footnote{\url{https://www.jabref.org/}}
 
 
 \subsubsection{Verwendung von \texttt{biblatex} und \texttt{biber}}
@@ -286,7 +286,7 @@ BibTeX-Verzeichnissen, wie beispielsweise
 Dieses Dokument verwendet \texttt{biblatex} (Version 1.4 oder höher) in Verbindung
 mit dem Programm \texttt{biber}, 
 das viele Unzulänglichkeiten des traditionellen BibTeX-Work\-flows behebt und dessen Möglichkeiten deutlich erweitert.%
-\footnote{Tatsächlich ist \texttt{biblatex} die erste radikale (und längst notwendige) Überarbeitung des mittlerweile stark in die Jahre gekommenen BibTeX-Workflows. Zwar wird dabei BibTex weiterhin für 
+\footnote{Tatsächlich ist \texttt{biblatex} die erste radikale (und längst notwendige) Überarbeitung des mittlerweile stark in die Jahre gekommenen BibTeX-Workflows. Zwar wird dabei BibTeX weiterhin für 
 die Sortierung der Quellen verwendet, die Formatierung der Einträge und viele andere Elemente werden jedoch ausschließlich über \latex-Makros gesteuert.}
 Allerdings sind die in \texttt{biblatex} verwendeten Literaturdaten nicht mehr vollständig 
 rückwärts-kompatibel zu BibTeX. Es ist daher in der Regel notwendig, bestehende oder aus
@@ -341,7 +341,7 @@ bei Bedarf relativ leicht möglich.}
 %
 \begin{itemize}
 	\item[] \textsf{literature} -- für klassische Publikationen, die gedruckt oder online vorliegen;
-	\item[] \textsf{avmedia} -- für Filme, audio-visuelle Medien (auf DVD, CD, \usw);
+	\item[] \textsf{avmedia} -- für Filme, audio-visuelle Medien (auf DVD, Streaming \usw);
 	\item[] \textsf{software} -- für Softwareprodukte, APIs, Computer Games;
 	\item[] \textsf{online} -- für Artefakte, die \emph{ausschließlich} online verfügbar sind.
 \end{itemize}
@@ -363,7 +363,7 @@ zugeordnet.
 	\emph{Literatur} (\textsf{literature}) & Typ & Seite\\
 	\hline
 	Buch (Textbuch, Monographie) & \texttt{@book} & \pageref{sec:@book}\\
-	Sammelband (Hrsg.\ + mehrere Autoren) & \texttt{@incollection} & \pageref{sec:@incollection} \\
+	Sammelband (Hrsg.\ + mehrere Autor*innen) & \texttt{@incollection} & \pageref{sec:@incollection} \\
 	Konferenz-, Tagungsband & \texttt{@inproceedings} & \pageref{sec:@inproceedings}\\
 	Beitrag in Zeitschrift, Journal & \texttt{@article} & \pageref{sec:@article}\\
 	Bachelor-, Master-, Diplomarbeit, Dissertation & \texttt{@thesis} & \pageref{sec:@thesis}\\
@@ -436,7 +436,7 @@ angegeben, gefolgt vom zugehörigen Ergebnis im Quellenverzeichnis.
 
 \subsubsection{\texttt{@book}}
 \label{sec:@book}
-Ein einbändiges Buch (Monographie), das von einem Autor oder mehreren Autoren zur Gänze gemeinsam verfasst und (typischerweise) von einem Verlag herausgegeben wurde.
+Ein einbändiges Buch (Monographie), das von einem*einer Autor*in oder mehreren Autor*innen zur Gänze gemeinsam verfasst und (typischerweise) von einem Verlag herausgegeben wurde.
 % 
 \begin{itemize}
 \item[] 
@@ -465,9 +465,9 @@ wenn diese die einzige ist!
 \subsubsection{\texttt{@incollection}}
 \label{sec:@incollection}
 Ein in sich abgeschlossener und mit einem eigenen Titel versehener
-Beitrag eines oder mehrerer Autoren in einem Buch oder Sammelband.
+Beitrag eines oder mehrerer Autor*innen in einem Buch oder Sammelband.
 Dabei ist \texttt{title} der Titel des Beitrags, \texttt{booktitle} der Titel des Sammelbands und
-\texttt{editor} der Name des Herausgebers.
+\texttt{editor} der Name des*der Herausgebers*Herausgeberin.
 %
 \begin{itemize}
 \item[] 
@@ -578,30 +578,31 @@ insbesondere die bekannten BibTeX-Einträge \texttt{@phdthesis} (für Dissertati
 \item[\cite{Eberl1987}] \fullcite{Eberl1987}
 \end{itemize}
 
-\paragraph{Magister- oder Masterarbeit:} ~ \newline
-Analog zur Dissertation (s.\ oben), allerdings mit \texttt{type=\{mathesis\}}.%
+\paragraph{Diplomarbeit:} ~ \newline
+Analog zur Dissertation (s.\ oben), allerdings mit \texttt{type=\obnh\{Diplomarbeit\}}:%
 
 %%------------------------------------------------------
 
-\paragraph{Diplomarbeit:} ~ \newline
-Analog zur Dissertation (s.\ oben), allerdings mit \texttt{type=\obnh\{Diplomarbeit\}}:%
+\paragraph{Magister- oder Masterarbeit:} ~ \newline
+Analog zur Dissertation (s.\ oben), allerdings mit \texttt{type=\{mathesis\}}.%
+
 %
 \begin{itemize}
 \item[]
 \begin{GenericCode}[numbers=none]
-@thesis{Artner2007,
-  author={Artner, Nicole Maria},
-  title={Analyse und Reimplementierung des Mean-Shift Tracking-Verfahrens},
-  type={Diplomarbeit},
-  year={2007},
-  month={7},
-  institution={University of Applied Sciences Upper Austria, Digitale Medien},
+@thesis{Loimayr2019,
+  author={Loimayr, Nora},
+  title={Utilization of GPU-Based Smoothed Particle Hydrodynamics for Immersive Audiovisal Experiences},
+  type={mathesis},
+  year={2019},
+  month={11},
+  institution={University of Applied Sciences Upper Austria, Interactive Media},
   location={Hagenberg, Austria},
-  url={http://theses.fh-hagenberg.at/thesis/Artner07},
-  hyphenation={german}
+  url={https://theses.fh-hagenberg.at/thesis/Loimayr19},
+  hyphenation={english}
 }
 \end{GenericCode}
-\item[\cite{Artner2007}] \fullcite{Artner2007}
+\item[\cite{Loimayr2019}] \fullcite{Loimayr2019}
 \end{itemize}
 %
 Der Inhalt des Felds \verb!url={..}! wird dabei automatisch und ohne zusätzliche
@@ -660,7 +661,7 @@ Adresse angegeben wird. Sinnvollerweise wird auch der zugehörige URL angegeben,
 
 \subsubsection{\texttt{@manual}}
 \label{sec:@manual}
-Dieser Publikationstyp bietet sich jegliche Art von technischer oder anderer Dokumentation an, wie etwa Produktbeschreibungen von Herstellern, Anleitungen, Präsentationen, White Papers \usw Die Dokumentation muss dabei nicht zwingend gedruckt existieren.
+Dieser Publikationstyp bietet sich jegliche Art von technischer oder anderer Dokumentation an, wie etwa Produktbeschreibungen, Anleitungen, Präsentationen, White Papers \usw Die Dokumentation muss dabei nicht zwingend gedruckt existieren.
 %
 \begin{itemize}
 \item[]
@@ -678,7 +679,7 @@ Dieser Publikationstyp bietet sich jegliche Art von technischer oder anderer Dok
 \item[\cite{Mittelbach2018}] \fullcite{Mittelbach2018}
 \end{itemize}
 %
-Oft wird bei derartigen Dokumenten kein Autor genannt. Dann wird der Name des \emph{Unternehmens} oder der \emph{Institution} im \texttt{author}-Feld angegeben, allerdings innerhalb einer \textbf{zusätzlichen Klammer} \texttt{\{..\}}, damit das Argument nicht fälschlicherweise als \emph{Vornamen} + \emph{Nachname} interpretiert wird.%
+Oft wird bei derartigen Dokumenten kein*e Autor*in genannt. Dann wird der Name des \emph{Unternehmens} oder der \emph{Institution} im \texttt{author}-Feld angegeben, allerdings innerhalb einer \textbf{zusätzlichen Klammer} \texttt{\{..\}}, damit das Argument nicht fälschlicherweise als \emph{Vornamen} + \emph{Nachname} interpretiert wird.%
 \footnote{Im Unterschied zu BibTeX wird in \texttt{biblatex} bei \texttt{@manual}-Einträgen das Feld \texttt{organization} nicht als Ersatz für \texttt{author} akzeptiert.}
 Dieser Trick wird \ua\ im nächsten Beispiel verwendet.
 
@@ -736,7 +737,7 @@ Patenterteilung, die Angabe von \texttt{holder} ist optional:
 \end{itemize}
 %
 \texttt{@patent} ist allerdings kein Standardtyp und daher wird nicht
-von allen BibTex-Imple\-mentier\-ungen unterstützt.
+von allen BibTeX-Imple\-mentier\-ungen unterstützt.
 Alternativ kann man für Patente auch den \texttt{@misc}-Typ verwenden,
 wie im nächsten Abschnitt gezeigt \cite{Hough1962}.
 
@@ -790,7 +791,7 @@ Hier ist ein weiteres Beispiel zur Verwendung von \texttt{@misc} für ein \emph{
 \label{sec:Musiknoten}
 
 Für gedruckte Kompositionen%
-\footnote{Engl.\ \emph{sheet music} oder \emph{musical scores}} gibt es in BibTex leider keinen
+\footnote{Engl.\ \emph{sheet music} oder \emph{musical scores}} gibt es in BibTeX leider keinen
 speziellen Eintragstyp. Bei einer \emph{einzelnen} Ausgabe verwendet man am Einfachsten den Typ 
 \texttt{@book}, wie \zB\ (\sa\ \cite{HaydnCelloConcerto2,ShostakovichOp110})
 %
@@ -834,14 +835,14 @@ kann man -- wie für einen Sammelband -- den Typ \texttt{@incollection} verwende
 \label{sec:@unpublished}
 
 Es kommt immer häufiger vor, dass Manuskripte längere Zeit vor der eigentlichen Pub\-likation
-von den Autoren online veröffentlicht werden,
+von den Autor*innen online veröffentlicht werden,
 beispielsweise auf Plattformen wie \textsf{arXiv.org}% 
 \footnote{\url{https://arxiv.org/}}
 oder \textsf{researchgate.net}.%
 \footnote{\url{https://www.researchgate.net/}}
 Dabei ist zu beachten, dass die Onlinestellung formell \textbf{keine Publikation}
 darstellt, da diese Plattformen keine Publikationsmedien sind.
-Tatsächlich werden manche der (von den Autoren selbst hochgeladenen) Arbeiten \emph{nie}
+Tatsächlich werden manche der (von den Autor*innen selbst hochgeladenen) Arbeiten \emph{nie}
 publiziert, etwa Einreichungen zu Konferenzen.
 Hier ist wichtig festzustellen, ob der Beitrag tatsächlich
 angenommen und auch publiziert wurde:
@@ -861,7 +862,7 @@ Publikation (oder ein zugehöriger \emph{Technical Report}, \so) findet,  kann m
   author = {Dai, Jifeng and Li, Yi and He, Kaiming and Sun, Jian},
   title = {{R-FCN:} Object Detection via Region-based Fully ...},
   year = {2016},
-  url = {http://arxiv.org/abs/1605.06409},
+  url = {https://arxiv.org/abs/1605.06409},
   pubstate = {prepublished}
 }
 \end{GenericCode}
@@ -982,8 +983,9 @@ Hier ein Beispiel für den Verweis auf eine DVD-Edition:
 \end{itemize}
 %
 In diesem Fall ist das angegebene Datum der \emph{Erscheinungstermin}. 
-Falls kein eindeutiger Autor namhaft gemacht werden kann, lässt man das
-\texttt{author}-Feld weg und verpackt die entsprechenden Angaben im \texttt{note}-Feld, wie im nachfolgenden Beispiel gezeigt.
+Falls kein*e eindeutige*r Autor*in namhaft gemacht werden kann, lässt man das
+\texttt{author}-Feld weg und verpackt die entsprechenden Angaben im
+\texttt{note}-Feld, wie im nachfolgenden Beispiel gezeigt.
 
 
 
@@ -991,7 +993,7 @@ Falls kein eindeutiger Autor namhaft gemacht werden kann, lässt man das
 \subsubsection{\texttt{@movie}}
 \label{sec:@movie}
 Dieser Eintragstyp ist für Filme reserviert. 
-Hier wird von vornherein \emph{kein} Autor angegeben, weil dieser bei 
+Hier wird von vornherein \emph{kein*e} Autor*in angegeben, weil diese*r bei 
 einer Filmproduktion \ia\ nicht eindeutig zu benennen ist. 
 Im folgenden Beispiel (\sa\ \cite{Psycho1960}) sind die betreffenden Daten 
 im \texttt{note}-Feld angegeben:%
@@ -1101,20 +1103,20 @@ Durch den Umfang und die steigende Qualität dieser Einträge erscheint
 die Aufnahme in das Quellenverzeichnis durchaus berechtigt.
 Beispielsweise bezeichnet man als "Reliquienschrein"
 einen Schrein, in dem die Reliquien eines oder 
-mehrerer Heiliger aufbewahrt werden \cite{WikiReliquienschrein2018}.
+mehrerer Heiliger aufbewahrt werden \cite{WikiReliquienschrein2020}.
 %
 \begin{itemize}
 \item[]
 \begin{GenericCode}[numbers=none]
-@online{WikiReliquienschrein2018,
-	title={Reliquienschrein},
-	url={https://de.wikipedia.org/wiki/Reliquienschrein},
-	year={2018},
-	month={9},
-	urldate={2019-02-28}
+@online{WikiReliquienschrein2020,
+  url={https://de.wikipedia.org/wiki/Reliquienschrein},
+  title={Reliquienschrein},
+  year={2020},
+  month={10},
+  urldate={2020-10-27}
 }
 \end{GenericCode}
-\item[\cite{WikiReliquienschrein2018}] \fullcite{WikiReliquienschrein2018}
+\item[\cite{WikiReliquienschrein2020}] \fullcite{WikiReliquienschrein2020}
 \end{itemize}
 %
 In diesem Fall besteht die Quellenangabe praktisch nur mehr aus dem URL.
@@ -1212,7 +1214,7 @@ unvollständig, inkonsistent oder syntaktisch fehlerhaft!
 Sie sollten bei der Übernahme \emph{immer} auf Korrektheit überprüft werden!
 Besonders sollte dabei auf die richtige Angabe der Vornamen (VN) und Nachnamen (NN) geachtet werden,
 nämlich in der Form%
-\footnote{\texttt{and} ist hier ein fixes Trennwort zwischen den Namen der einzelnen Autoren.}
+\footnote{\texttt{and} ist hier ein fixes Trennwort zwischen den Namen der einzelnen Autor*innen.}
 \begin{itemize}
 \item[]
 \texttt{author=\{\textit{NN1}, \textit{VN1a} \emph{VN1b} and \textit{NN2}, \textit{VN2a} \ldots \}}.
@@ -1241,7 +1243,7 @@ Hier ist eine Liste der häufigsten Fehler im Zusammenhang mit dem Quellenverzei
 \item
 Alle Einträge auf fehlende oder falsch interpretierte Elemente überprüfen!
 \item
-Alle Namen und Vornamen der Autoren überprüfen, sind die Abkürzungen (der Vornamen) konsistent?
+Alle Namen und Vornamen der Autor*innen überprüfen, sind die Abkürzungen (der Vornamen) konsistent?
 \item
 Groß-/Kleinschreibung und Satzzeichen in allen  Einträgen überprüfen und ggfs.\ korrigieren.
 \item
@@ -1294,4 +1296,4 @@ Insbesondere ist es nicht zulässig, eine Quelle nur eingangs zu erwähnen und n
 Auf gar keinen Fall tolerierbar ist die direkte Übernahme oder \emph{Paraphrase} längerer Textpassagen, egal ob mit oder ohne Quellenangabe. Auch indirekt übernommene oder aus einer anderen Sprache übersetzte Passagen müssen mit entsprechenden Quellenangaben gekennzeichnet sein! 
 \end{itemize}
 %
-Im Zweifelsfall finden sich detailliertere Regeln in jedem guten Buch über wissenschaftliches Arbeiten oder man fragt sicherheitshalber den Betreuer der Arbeit.
+Im Zweifelsfall finden sich detailliertere Regeln in jedem guten Buch über wissenschaftliches Arbeiten oder man fragt sicherheitshalber den*die Betreuer*in der Arbeit.

--- a/documents/HgbThesisTutorial/chapters/mathematik.tex
+++ b/documents/HgbThesisTutorial/chapters/mathematik.tex
@@ -91,7 +91,7 @@ Bei Unsicherheiten sollte man sich passende Beispiele in einem guten Mathematik\
 \end{minipage}}
 \end{center}
 %
-Für Interessierte findet sich mehr zum Thema Mathematik und Prosa in \cite{Mermin1989} und \cite{Higham1998}.
+Für Interessierte findet sich mehr zum Thema Mathematik und Prosa in \cite{Mermin1989} und \cite{Higham2020}.
 
 \subsection{Mehrzeilige Gleichungen}
 
@@ -99,7 +99,7 @@ Für mehrzeilige Gleichungen bietet \latex\ die
 \verb!eqnarray!-Umgebung, die allerdings etwas eigenwillige Zwischenräume erzeugt.
 Es empfiehlt sich, dafür gleich auf die erweiterten Möglichkeiten des \texttt{amsmath}-Pakets%
 \footnote{American Mathematical Society (AMS). \texttt{amsmath} ist Teil der \latex\ Standardinstallation und wird von \texttt{hgb.sty} bereits importiert.}
-\cite{Mittelbach2018} zurückzugreifen.
+\cite{Mittelbach2020} zurückzugreifen.
 Hier ein Beispiel mit zwei am $=$ Zeichen ausgerichteten Gleichungen,
 %
 \begin{align}
@@ -181,7 +181,7 @@ das mit den folgenden Anweisungen erzeugt wurde:
 %
 Ein nützliches Detail darin ist das \tex-Makro \verb!\phantom{..}! (in Zeile \ref{lin:phantom}), das sein Argument unsichtbar einfügt und hier als Platzhalter für das darüberliegende Minuszeichen verwendet wird. Alternativ zu \texttt{pmatrix} kann mit der \texttt{bmatrix}-Umgebung Matrizen
 und Vektoren mit eckigen Klammern erzeugt werden.
-Zahlreiche weitere mathematische Konstrukte des \texttt{amsmath}-Pakets sind in \cite{Mittelbach2018} beschrieben.
+Zahlreiche weitere mathematische Konstrukte des \texttt{amsmath}-Pakets sind in \cite{Mittelbach2020} beschrieben.
 
 \begin{comment}
 % Umsetzung ohne amsmath:

--- a/documents/HgbThesisTutorial/chapters/mathematik.tex
+++ b/documents/HgbThesisTutorial/chapters/mathematik.tex
@@ -384,7 +384,7 @@ $\wedge$ (\verb!$\wedge$!) statt \texttt{\&\&},
 \usw
 \item
 Verwende keine Elemente oder Syntax einer spezifischen Programmiersprache
-(\zB\ ist ein "\texttt{;}" am Ende einer Anweisung unnötig).
+(so ist etwa ein "\texttt{;}" am Ende einer Anweisung unnötig).
 \item
 Wenn ein Algorithmus für eine Seite zu lang wird, überlege, wie man ihn
 sinnvoll auf kleinere Module aufteilen kann (meist ist dann auch die zugehörige

--- a/documents/HgbThesisTutorial/chapters/schluss.tex
+++ b/documents/HgbThesisTutorial/chapters/schluss.tex
@@ -36,7 +36,7 @@ Abschließend noch eine kurze Liste der wichtigsten Punkte, an denen erfahrungsg
 \item[$\Box$] \textbf{Titelseite:} 
 	Länge des Titels (Zeilenumbrüche), Name, Studiengang, Datum.
 \item[$\Box$] \textbf{Erklärung:} 
-vollständig Unterschrift.
+vollständige Unterschrift.
 \item[$\Box$] \textbf{Inhaltsverzeichnis:}
 	balancierte Struktur, Tiefe, Länge der Überschriften.
 \item[$\Box$] \textbf{Kurzfassung/Abstract:} 

--- a/documents/HgbThesisTutorial/chapters/schluss.tex
+++ b/documents/HgbThesisTutorial/chapters/schluss.tex
@@ -46,6 +46,9 @@ vollständige Unterschrift.
 \item[$\Box$] \textbf{Typographie:}
 	sauberes Schriftbild, keine "manuellen" Abstände zwischen Absätzen oder Einrückungen, 
 	keine überlangen Zeilen, Hervorhebungen, Schriftgröße, Platzierung von Fußnoten.
+\item[$\Box$] \textbf{Sprache:}
+	geschlechtergerechte Formulierungen (kein generisches Maskulinum oder Generalklausel),
+	neutraler, sachlicher Stil, keine übermäßigen Anglizismen.
 \item[$\Box$] \textbf{Interpunktion:} 
 	Binde- und Gedankenstriche richtig gesetzt, Abstände nach Punkten (\va\ nach Abkürzungen),
 	korrekte (vordere/hintere) Hochkommas.

--- a/documents/HgbThesisTutorial/front/kurzfassung.tex
+++ b/documents/HgbThesisTutorial/front/kurzfassung.tex
@@ -6,7 +6,7 @@ Kurzfassung (und das Abstract) üblicherweise nicht in Abschnitte
 und Unterabschnitte gegliedert. 
 Auch Fußnoten sind hier falsch am Platz.
 
-Kurzfassungen werden übrigens häufig -- zusammen mit Autor und Titel
+Kurzfassungen werden übrigens häufig -- zusammen mit Autor*in und Titel
 der Arbeit -- %
 in Literaturdatenbanken aufgenommen. Es ist daher darauf zu
 achten, dass die Information in der Kurzfassung für sich 
@@ -29,6 +29,6 @@ Regel verloren gehen. Dasselbe gilt natürlich auch für das
 
 Inhaltlich sollte die Kurzfassung \emph{keine} Auflistung der
 einzelnen Kapitel sein (dafür ist das Einleitungskapitel
-vorgesehen), sondern dem Leser einen kompakten, inhaltlichen
+vorgesehen), sondern dem*der Leser*in einen kompakten, inhaltlichen
 Überblick über die gesamte Arbeit verschaffen. Der hier verwendete
 Aufbau ist daher zwangsläufig anders als der in der Einleitung.

--- a/documents/HgbThesisTutorial/front/vorwort.tex
+++ b/documents/HgbThesisTutorial/front/vorwort.tex
@@ -18,7 +18,7 @@ Grafiken anbelangt, doch eine wesentlich andere Arbeitsweise
 verlangt. Das Ergebnis ist -- von Grund auf neu geschrieben und
 wesentlich umfangreicher als das vorherige Dokument --
 letztendlich eine Anleitung für das Schreiben mit \latex, ergänzt
-mit einigen speziellen (mittlerweile entfernten) Hinweisen für \emph{Word}-Benutzer.
+mit einigen speziellen (mittlerweile entfernten) Hinweisen für \emph{Word}-Benutzer*innen.
 Technische Details zur aktuellen Version finden sich in Anhang \ref{app:TechnischeInfos}.
 
 Während dieses Dokument anfangs ausschließlich für die Erstellung
@@ -33,28 +33,28 @@ tat\-säch\-lich ist eine Reihe von ergänzenden "Paketen" notwendig, wobei jedo
 nur auf gängige Erweiterungen zurückgegriffen wurde.
 Selbstverständlich gibt es darüber hinaus eine Vielzahl weiterer Pakete,
 die für weitere Verbesserungen und Finessen nützlich sein können. Damit kann
-sich aber jeder selbst beschäftigen, sobald das notwendige Selbstvertrauen und
+sich aber jede*r selbst beschäftigen, sobald das notwendige Selbstvertrauen und
 genügend Zeit zum Experimentieren vorhanden sind.
 Eine Vielzahl von Details und Tricks sind zwar in diesem Dokument nicht explizit
 angeführt, können aber im zugehörigen Quelltext jederzeit ausgeforscht
 werden.
 
-Zahlreiche KollegInnen haben durch sorgfältiges Korrekturlesen und
+Zahlreiche Kolleg*innen haben durch sorgfältiges Korrekturlesen und
 konstruktive Verbesserungsvorschläge wertvolle Unterstützung
 geliefert. Speziell bedanken möchte ich mich bei Heinz Dobler für
 die konsequente Verbesserung meines "Computer Slangs", bei
 Elisabeth Mitterbauer für das bewährte orthographische Auge und
-bei Wolfgang Hochleitner für die Tests unter Mac~OS.
+bei Wolfgang Hochleitner für die Mitarbeit an verschiedensten Stellen.
 
-Die Verwendung dieser Vorlage ist jedermann freigestellt und an
+Die Verwendung dieser Vorlage ist uneingeschränkt freigestellt und an
 keinerlei Erwähnung gebunden. Allerdings -- wer sie als Grundlage
-seiner eigenen Arbeit verwenden möchte, sollte nicht einfach
+der eigenen Arbeit verwenden möchte, sollte nicht einfach
 ("ung'schaut") darauf los werken, sondern zumindest die
 wichtigsten Teile des Dokuments \emph{lesen} und nach Möglichkeit
 auch beherzigen. Die Erfahrung zeigt, dass dies die Qualität der
 Ergebnisse deutlich zu steigern vermag.
 
-Dieses Dokument und die zugehörigen \latex-Klassen sind seit Nov.\ 2017 auf CTAN%
+Dieses Dokument und die zugehörigen \latex-Klassen sind seit November 2017 auf CTAN%
 \footnote{Comprehensive TeX Archive Network} 
 als Paket \texttt{hagenberg-thesis} verfügbar unter
 %
@@ -90,8 +90,8 @@ Fachhochschule Oberösterreich, Campus Hagenberg (Österreich)\newline
 \noindent
 Übrigens, hier im Vorwort (das bei Diplom- und Masterarbeiten üblich, bei Bachelorarbeiten 
 aber entbehrlich ist) kann kurz auf die Entstehung des Dokuments eingegangen werden.
-Hier ist auch der Platz für allfällige Danksagungen (\zB an den Betreuer, 
-den Begutachter, die Familie, den Hund, \ldots), Widmungen und philosophische 
+Hier ist auch der Platz für allfällige Danksagungen (\zB an den*die Betreuer*in, 
+den*die Begutachter*in, die Familie, den Hund, \ldots), Widmungen und philosophische 
 Anmerkungen. Das sollte man allerdings auch nicht übertreiben und auf 
 einen Umfang von maximal zwei Seiten beschränken.
 

--- a/documents/HgbThesisTutorial/main.tex
+++ b/documents/HgbThesisTutorial/main.tex
@@ -27,14 +27,14 @@
 
 %%% Einträge für ALLE Arbeiten: -----------------------------
 \title{Partielle Lösungen zur allgemeinen Problematik}
-\author{Peter A.\ Schlaumeier}
+\author{Alex A.\ Schlaumeier}
 \programname{Universal Computing}
 
 % \programtype{Fachhochschul-Bachelorstudiengang}		% select/edit
 \programtype{Fachhochschul-Masterstudiengang}
 
 \placeofstudy{Hagenberg}
-\dateofsubmission{2019}{07}{15}	% {YYYY}{MM}{DD}
+\dateofsubmission{2021}{07}{15}	% {YYYY}{MM}{DD}
 
 \advisor{Alois B.~Treuer, Päd.\ Phil.}	% optional
 

--- a/documents/HgbThesisTutorial/references.bib
+++ b/documents/HgbThesisTutorial/references.bib
@@ -11,12 +11,12 @@
 	hyphenation={german}
 }
 
-@manual{Bezos2018,
+@manual{Bezos2020,
 	author={Bezos, Javier and Braams, Johannes L.},
 	title={Babel -- Multilingual support for Plain \TeX\ or \LaTeX},
-	year={2018},
-	month={11},
-	version={3.27},
+	year={2020},
+	month={10},
+	version={3.50},
 	url={http://mirrors.ctan.org/macros/latex/required/babel/base/babel.pdf},
 	hyphenation={english}
 }
@@ -70,11 +70,11 @@
 	hyphenation={english}
 }
 
-@manual{Carlisle2017,
+@manual{Carlisle2020,
 	author={Carlisle, David P.},
 	title={Packages in the {`graphics'} bundle},
-	year={2017},
-	month={6},
+	year={2020},
+	month={8},
 	url={http://mirrors.ctan.org/macros/latex/required/graphics/grfguide.pdf},
 	hyphenation={english},
 }
@@ -207,13 +207,13 @@
 	hyphenation={german}
 }
 
-@book{Higham1998,
+@book{Higham2020,
 	author={Higham, Nicholas J.},
 	title={Handbook of Writing for the Mathematical Sciences},
 	publisher={Society for Industrial and Applied Mathematics (SIAM)},
 	location={Philadelphia},
-	edition={2},
-	year={1998},
+	edition={3},
+	year={2020},
 	url={https://www.maths.manchester.ac.uk/~higham/hwms/},
 	hyphenation={english}
 }
@@ -240,6 +240,17 @@
 	title={System 360},
 	subtitle={From Computers to Computer Systems},
 	url={https://www.ibm.com/ibm/history/ibm100/us/en/icons/system360/impacts/}
+}
+
+@manual{Kime2020,
+	author={Kime, Philip and Wemheuer, Moritz and Lehman, Philipp},
+	title={The \texttt{biblatex} Package},
+	subtitle={Programmable Bibliographies and Citations},
+	year={2020},
+	month={8},
+	version={3.15},
+	url={http://mirrors.ctan.org/macros/latex/contrib/biblatex/doc/biblatex.pdf},
+	hyphenation={english}
 }
 
 @book{Kopka2003,
@@ -283,17 +294,6 @@
 	hyphenation={english}
 }
 
-@manual{Lehman2018,
-	author={Lehman, Philipp and Kime, Philip and Wemheuer, Moritz and Boruvka, Audrey and Wright, Joseph},
-	title={The \texttt{biblatex} Package},
-	subtitle={Programmable Bibliographies and Citations},
-	year={2018},
-	month={10},
-	version={3.12},
-	url={http://mirrors.ctan.org/macros/latex/contrib/biblatex/doc/biblatex.pdf},
-	hyphenation={english}
-}
-
 @thesis{Loimayr2019,
 	author={Loimayr, Nora},
 	title={Utilization of GPU-Based Smoothed Particle Hydrodynamics for Immersive Audiovisal Experiences},
@@ -317,12 +317,12 @@
 	hyphenation={english}
 }
 
-@manual{Mittelbach2018,
+@manual{Mittelbach2020,
 	author={Mittelbach, Frank and Schöpf, Rainer and Downes, Michael and Jones, David M. and Carlisle, David},
 	title={The \texttt{amsmath} package},
-	year={2018},
-	month={12},
-	version={2.17b},
+	year={2020},
+	month={9},
+	version={2.17i},
 	url={http://mirrors.ctan.org/macros/latex/required/amsmath/amsmath.pdf},
 	hyphenation={english}
 }
@@ -363,11 +363,11 @@
 	hyphenation={english}
 }
 
-@manual{Pakin2017,
+@manual{Pakin2020,
 	author={Pakin, Scott},
 	title={The Comprehensive {LaTeX} Symbol List},
-	year={2017},
-	month={1},
+	year={2020},
+	month={6},
 	url={http://mirrors.ctan.org/info/symbols/comprehensive/symbols-a4.pdf},
 	hyphenation={english}
 }
@@ -423,11 +423,11 @@
 	hyphenation={english}
 }
 
-@manual{Sommerfeldt2011,
+@manual{Sommerfeldt2020,
 	author={Sommerfeldt, Axel},
 	title={Anpassen der Abbildungs- und Tabellenbeschriftungen},
-	year={2011},
-	month={11},
+	year={2020},
+	month={8},
 	url={http://mirrors.ctan.org/macros/latex/contrib/caption/caption-deu.pdf},
 	hyphenation={german}
 }
@@ -485,7 +485,7 @@
 	author={Dai, Jifeng and Li,Yi and He, Kaiming and Sun, Jian},
 	title={{R-FCN:} Object Detection via Region-based Fully Convolutional Networks},
 	year={2016},
-	url={http://arxiv.org/abs/1605.06409},
+	url={https://arxiv.org/abs/1605.06409},
 	pubstate = {prepublished}
 }
 

--- a/documents/HgbThesisTutorial/references.bib
+++ b/documents/HgbThesisTutorial/references.bib
@@ -1,17 +1,5 @@
 %%% Biber accepts '%' for marking comments
 
-@thesis{Artner2007,
-	author={Artner, Nicole Maria},
-	title={Analyse und Reimplementierung des Mean-Shift Tracking-Verfahrens},
-	type={Diplomarbeit},
-	year={2007},
-	month={7},
-	institution={University of Applied Sciences Upper Austria, Digitale Medien},
-	location={Hagenberg, Austria},
-	url={http://theses.fh-hagenberg.at/thesis/Artner07},
-	hyphenation={german}
-}
-
 @thesis{Bacher2004,
 	author={Bacher, Florian},
 	title={Interaktionsmöglichkeiten mit Bildschirmen und großflächigen Projektionen},
@@ -306,6 +294,18 @@
 	hyphenation={english}
 }
 
+@thesis{Loimayr2019,
+	author={Loimayr, Nora},
+	title={Utilization of GPU-Based Smoothed Particle Hydrodynamics for Immersive Audiovisal Experiences},
+	type={mathesis},
+	year={2019},
+	month={11},
+	institution={University of Applied Sciences Upper Austria, Interactive Media},
+	location={Hagenberg, Austria},
+	url={https://theses.fh-hagenberg.at/thesis/Loimayr19},
+	hyphenation={english}
+}
+
 @article{Mermin1989,
 	author={Mermin, Nathaniel David},
 	title={What's wrong with these equations?},
@@ -459,12 +459,12 @@
 
 %%% Beispiel für Online-Quelle -----------------------------------------
 
-@online{WikiReliquienschrein2018,
+@online{WikiReliquienschrein2020,
 	url={https://de.wikipedia.org/wiki/Reliquienschrein},
 	title={Reliquienschrein},
-	year={2018},
-	month={9},
-	urldate={2019-02-28}
+	year={2020},
+	month={10},
+	urldate={2020-10-27}
 }
 
 %%% Beispiel für Audio-Aufnahme -----------------------------------------

--- a/documents/HgbThesisTutorial/references.bib
+++ b/documents/HgbThesisTutorial/references.bib
@@ -483,7 +483,7 @@
 
 @unpublished{DaiLHS16,
 	author={Dai, Jifeng and Li,Yi and He, Kaiming and Sun, Jian},
-	title={{R-FCN:} Object Detection via Region-based Fully Convolutional Networks},
+	title={{R-FCN:} Object Detection via Region-Based Fully Convolutional Networks},
 	year={2016},
 	url={https://arxiv.org/abs/1605.06409},
 	pubstate = {prepublished}


### PR DESCRIPTION
This PR contains a few changes, the most important being that all German template documents (mostly the thesis template) now adhere to gender-sensitive language using the asterisk (\*) notation. Here are the changes in detail:

- All mentions of persons, responsibilities, or activities that were phrased in the masculine form (e.g., Autor) has been replaced with a form that included the whole gender-spectrum (e.g., der\*die Autor\*in).
- Example names, such as the one of the fictional student "Peter A. Schlaumeier," have been switched to a neutral form. Alex was chosen since it works in every direction.
- References were updated. Some outdated ones were removed (e.g., the old Master's thesis example from Digitale Medien since the URL to the PDF was no longer active). Others were updated (mostly the LaTeX package manuals, also a book).
- A few typos and punctuations were fixed, and links were updated.
- Submission dates were forwarded to 2021.
- Most overfull boxes were corrected.

@imagingbook, have a look at it and see if you find the changes okay. There's no rebuild included, just the bare changes in the tex and bib files.

I also think this would be a good time to publish a new release. The unreleased section in the changelog is rather long and full of cool new stuff.