### PR TITLE
Change how the deprecated subfigure package is detected

### DIFF
--- a/dev/latex/hgb.sty
+++ b/dev/latex/hgb.sty
@@ -314,8 +314,11 @@
 % compatible with our quality standards. Loading this package is therefore blocked
 % by default. We recommend to use the 'tabular' environment instead.
 
-\newcommand{\subfigure}{%
-\PackageError{hgb}{Use of the 'subfigure' package is not supported in this setup, because it is obsolete}{}}
+\AtBeginDocument{%
+  \@ifpackageloaded{subfigure}{%
+    \PackageError{hgb}{Use of the 'subfigure' package is not supported in this setup, because it is obsolete}{}
+  }%
+}%
 
 %% ----------------------------------------------------------------------------
 


### PR DESCRIPTION
# Change how the deprecated subfigure package is detected

It was previously checked whether the  `\subfigure` macro is defined. This clashes with another package [subcaption](https://ctan.org/pkg/subcaption) which uses the same macro.

While not being a LaTeX hacker, it seems to me that using `\ifpackageloaded` instead is a cleaner solution and allows to include the subcaption package or other packages which define `\subfigure`.