### PR TITLE
Fix usage of removed command \DeclareDocumentMetadata

### DIFF
--- a/dev/ctan/hagenberg-thesis/latex/hgbpdfa.sty
+++ b/dev/ctan/hagenberg-thesis/latex/hgbpdfa.sty
@@ -20,5 +20,5 @@
   {}%
   {\PackageWarning{hgbpdfa}{Package 'pdfmanagement-testphase' 0.95s or higher required, output may not be PDF/A!}}
 
-\DeclareDocumentMetadata{pdfversion=1.7,pdfstandard=A-2b}
+\DocumentMetadata{pdfversion=1.7,pdfstandard=A-2b}
 %% Specification of color profiles may follow here!


### PR DESCRIPTION
Fixes #195

(Not sure what's going on in #190 but this was a much simpler fix.)